### PR TITLE
Update Database Schema to include Notes table and Manual Alert option

### DIFF
--- a/docs/database/datamodel-schema.md
+++ b/docs/database/datamodel-schema.md
@@ -37,6 +37,7 @@ The idea behind this is to create a living document that would continue to be up
 | 12 | `coaching_tips` | AI tips for agents |
 | 13 | `notifications` | User notification inbox |
 | 14 | `briefs` | Stored team reports |
+| 15 | `notes` | User notes on calls |
 
 ---
 
@@ -216,7 +217,11 @@ For insertion, we'd do the following:
 | `call_id` | **Foreign Key** → calls, UNIQUE | One alert per call |
 | `supervisor_id` | **Foreign Key** → users | Alert recipient |
 | `team_id` | **Foreign Key** → teams | |
+| `type` | ENUM | `threshold` · `keyword` · `manual` |
+| `status` | ENUM | `open` · `closed` |
 | `severity` | ENUM | `low` · `medium` · `high` |
+| `title` | VARCHAR(255) | Alert headline |
+| `description` | TEXT | Alert details |
 | `is_read` | BOOLEAN | Read status |
 | `created_at` | TIMESTAMP | |
 | `updated_at` | TIMESTAMP | |
@@ -311,6 +316,20 @@ For insertion, we'd do the following:
 
 ---
 
+### 15. `notes`
+
+> User notes on calls
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | UUID, **Primary key** | |
+| `call_id` | **Foreign Key** → calls | Which call |
+| `user_id` | **Foreign Key** → users | Who wrote it |
+| `content` | TEXT | Note text |
+| `created_at` | TIMESTAMP | |
+
+---
+
 ## Relationships
 
 | Relationship | Type |
@@ -327,6 +346,7 @@ For insertion, we'd do the following:
 | Agent → Coaching Tips | One-to-Many |
 | User → Notifications | One-to-Many |
 | Team → Briefs | One-to-Many |
+| Call → Notes | One-to-Many |
 
 ---
 
@@ -337,7 +357,9 @@ user_role:  `agent`, `supervisor`
 
 sentiment_label:  `positive`, `neutral`, `negative`
 
-alert_type:  `threshold`, `keyword`
+alert_type:  `threshold`, `keyword`, `manual`
+
+alert_status:  `open`, `closed`
 
 alert_severity:  `low`, `medium`, `high`
 

--- a/migrations/1-add-alerts-fields-and-notes.sql
+++ b/migrations/1-add-alerts-fields-and-notes.sql
@@ -1,0 +1,44 @@
+-- ============================================================
+-- MIGRATION: Add alert fields + notes table
+-- ============================================================
+
+-- ============================================================
+-- 1. UPDATE EXISTING ENUM + ADD NEW ENUM
+-- ============================================================
+
+-- Add 'manual' to existing alert_type enum
+ALTER TYPE alert_type ADD VALUE 'manual';
+
+-- Create alert_status enum
+CREATE TYPE alert_status AS ENUM ('open', 'closed');
+
+-- ============================================================
+-- 2. ALTER ALERTS TABLE - Add new columns
+-- ============================================================
+
+ALTER TABLE alerts
+  ADD COLUMN type alert_type NOT NULL DEFAULT 'threshold',
+  ADD COLUMN status alert_status NOT NULL DEFAULT 'open',
+  ADD COLUMN title VARCHAR(255),
+  ADD COLUMN description TEXT;
+
+-- ============================================================
+-- 3. CREATE NOTES TABLE
+-- ============================================================
+
+CREATE TABLE notes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  call_id UUID NOT NULL REFERENCES calls(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ============================================================
+-- 4. INDEXES
+-- ============================================================
+
+CREATE INDEX idx_notes_call_id ON notes(call_id);
+CREATE INDEX idx_notes_user_id ON notes(user_id);
+CREATE INDEX idx_alerts_status ON alerts(status);
+CREATE INDEX idx_alerts_type ON alerts(type);

--- a/migrations/Datatbase.SQL
+++ b/migrations/Datatbase.SQL
@@ -1,0 +1,263 @@
+-- ============================================================
+-- ENUMS
+-- ============================================================
+
+CREATE TYPE user_role AS ENUM ('agent', 'supervisor');
+CREATE TYPE sentiment_label AS ENUM ('positive', 'neutral', 'negative');
+CREATE TYPE alert_type AS ENUM ('threshold', 'keyword');
+CREATE TYPE alert_severity AS ENUM ('low', 'medium', 'high');
+CREATE TYPE notification_type AS ENUM ('alert', 'coaching_tip', 'exemplar_added');
+CREATE TYPE notification_reference_type AS ENUM ('call', 'alert', 'coaching_tip', 'exemplar_call');
+
+-- ============================================================
+-- 1. USERS
+-- Extends Supabase auth.users
+-- ============================================================
+
+CREATE TABLE users (
+  id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  email VARCHAR(255) NOT NULL,
+  first_name VARCHAR(255),
+  last_name VARCHAR(255),
+  role user_role NOT NULL,
+  team_id UUID, -- FK added after teams table is created
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ============================================================
+-- 2. TEAMS
+-- ============================================================
+
+CREATE TABLE teams (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name VARCHAR(255) NOT NULL,
+  supervisor_id UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Now add the FK from users -> teams
+ALTER TABLE users
+  ADD CONSTRAINT fk_users_team
+  FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE SET NULL;
+
+-- ============================================================
+-- 3. CALLS
+-- ============================================================
+
+CREATE TABLE calls (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  team_id UUID NOT NULL REFERENCES teams(id) ON DELETE RESTRICT,
+  recording_url TEXT,
+  transcript JSONB, -- Array of {speaker, text} objects
+  duration_seconds INTEGER,
+  started_at TIMESTAMP WITH TIME ZONE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ============================================================
+-- 4. CALL ANALYSES
+-- ============================================================
+
+CREATE TABLE call_analyses (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  call_id UUID NOT NULL UNIQUE REFERENCES calls(id) ON DELETE CASCADE,
+  summary TEXT,
+  sentiment_score DECIMAL(4, 3) CHECK (sentiment_score BETWEEN -1.0 AND 1.0),
+  sentiment_label sentiment_label,
+  is_resolved BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ============================================================
+-- 5. TOPICS
+-- ============================================================
+
+CREATE TABLE topics (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name VARCHAR(100) NOT NULL UNIQUE,
+  description TEXT,
+  is_active BOOLEAN DEFAULT TRUE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ============================================================
+-- 6. KEYWORDS
+-- ============================================================
+
+CREATE TABLE keywords (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  word VARCHAR(100) NOT NULL UNIQUE,
+  is_active BOOLEAN DEFAULT TRUE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ============================================================
+-- 7. CALL ANALYSIS TOPICS (Join Table)
+-- ============================================================
+
+CREATE TABLE call_analysis_topics (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  call_analysis_id UUID NOT NULL REFERENCES call_analyses(id) ON DELETE CASCADE,
+  topic_id UUID NOT NULL REFERENCES topics(id) ON DELETE CASCADE,
+  UNIQUE (call_analysis_id, topic_id)
+);
+
+-- ============================================================
+-- 8. CALL ANALYSIS KEYWORDS (Join Table)
+-- ============================================================
+
+CREATE TABLE call_analysis_keywords (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  call_analysis_id UUID NOT NULL REFERENCES call_analyses(id) ON DELETE CASCADE,
+  keyword_id UUID NOT NULL REFERENCES keywords(id) ON DELETE CASCADE,
+  UNIQUE (call_analysis_id, keyword_id)
+);
+
+-- ============================================================
+-- 9. ALERT CONFIGURATIONS
+-- ============================================================
+
+CREATE TABLE alert_configurations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  supervisor_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  type alert_type NOT NULL,
+  sentiment_threshold DECIMAL(4, 3) CHECK (sentiment_threshold BETWEEN -1.0 AND 1.0),
+  keyword_id UUID REFERENCES keywords(id) ON DELETE SET NULL,
+  is_active BOOLEAN DEFAULT TRUE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ============================================================
+-- 10. ALERTS
+-- ============================================================
+
+CREATE TABLE alerts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  call_id UUID NOT NULL UNIQUE REFERENCES calls(id) ON DELETE CASCADE,
+  supervisor_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  severity alert_severity NOT NULL,
+  is_read BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ============================================================
+-- 11. EXEMPLAR CALLS
+-- ============================================================
+
+CREATE TABLE exemplar_calls (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  call_id UUID NOT NULL UNIQUE REFERENCES calls(id) ON DELETE CASCADE,
+  team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  marked_by UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  note TEXT,
+  key_moves JSONB, -- Array of strings describing what made the call great
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ============================================================
+-- 12. COACHING TIPS
+-- ============================================================
+
+CREATE TABLE coaching_tips (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  content JSONB NOT NULL, -- Array of tip strings
+  reason TEXT, -- Why the tip was generated
+  based_on_call_id UUID REFERENCES calls(id) ON DELETE SET NULL,
+  is_read BOOLEAN DEFAULT FALSE,
+  helpful BOOLEAN, -- Agent feedback - was tip useful?
+  bookmarked BOOLEAN DEFAULT FALSE,
+  dismissed BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ============================================================
+-- 13. NOTIFICATIONS
+-- ============================================================
+
+CREATE TABLE notifications (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type notification_type NOT NULL,
+  title VARCHAR(255) NOT NULL,
+  body TEXT,
+  reference_type notification_reference_type,
+  reference_id UUID,
+  is_read BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ============================================================
+-- 14. BRIEFS
+-- ============================================================
+
+CREATE TABLE briefs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  generated_by UUID NOT NULL REFERENCES users(id) ON DELETE RESTRICT,
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  total_calls INTEGER DEFAULT 0,
+  average_sentiment DECIMAL(4, 3),
+  positive_call_percentage DECIMAL(5, 2),
+  negative_call_percentage DECIMAL(5, 2),
+  top_issues JSONB,
+  content JSONB,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- ============================================================
+-- AUTO-UPDATE updated_at TRIGGER
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_users_updated_at
+  BEFORE UPDATE ON users FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+CREATE TRIGGER trg_teams_updated_at
+  BEFORE UPDATE ON teams FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+CREATE TRIGGER trg_call_analyses_updated_at
+  BEFORE UPDATE ON call_analyses FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+CREATE TRIGGER trg_alert_configurations_updated_at
+  BEFORE UPDATE ON alert_configurations FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+CREATE TRIGGER trg_alerts_updated_at
+  BEFORE UPDATE ON alerts FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+CREATE TRIGGER trg_notifications_updated_at
+  BEFORE UPDATE ON notifications FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ============================================================
+-- INDEXES (for common query patterns)
+-- ============================================================
+
+CREATE INDEX idx_users_team_id ON users(team_id);
+CREATE INDEX idx_calls_agent_id ON calls(agent_id);
+CREATE INDEX idx_calls_team_id ON calls(team_id);
+CREATE INDEX idx_calls_started_at ON calls(started_at);
+CREATE INDEX idx_call_analyses_call_id ON call_analyses(call_id);
+CREATE INDEX idx_call_analysis_topics_analysis_id ON call_analysis_topics(call_analysis_id);
+CREATE INDEX idx_call_analysis_keywords_analysis_id ON call_analysis_keywords(call_analysis_id);
+CREATE INDEX idx_alerts_supervisor_id ON alerts(supervisor_id);
+CREATE INDEX idx_alerts_team_id ON alerts(team_id);
+CREATE INDEX idx_coaching_tips_agent_id ON coaching_tips(agent_id);
+CREATE INDEX idx_notifications_user_id ON notifications(user_id);
+CREATE INDEX idx_briefs_team_id ON briefs(team_id);


### PR DESCRIPTION
## Summary
PR: https://github.com/fiyinfoluwaafol/aws-connect-insight/pull/123 showed that the database lacked some important fields to support frontend alert and notes. This PR addresses those issues. 

## Changes

- Added Notes table to schema with a foreign relationship to calls
- Added a new type of alert `manual`, in case supervisors wanted to create a call that had no automatic alert already created
- Include database migration scripts for future reference.
- Added extra `type`, `status` and `description` and `title` fields to alerts table

## Test Plan

- [x] Ran new migration script `migrations/1-add-alerts-fields-and-notes.sql` in supabase and manually verified new tables and enums