### PR TITLE
refactor(supervisor-dashboard): decompose monolithic pages into modular components

### DIFF
--- a/frontend/src/pages/supervisor/Alerts.tsx
+++ b/frontend/src/pages/supervisor/Alerts.tsx
@@ -1,49 +1,46 @@
-import { useState, useEffect } from 'react';
-import { mockData, Call } from '@/lib/mock-data';
+import { useState, useEffect, useMemo } from 'react';
+import { mockData } from '@/lib/mock-data';
+import type { Call } from '@/lib/mock-data';
 import { useAppStore } from '@/stores/app-store';
-import { SentimentBadge } from '@/components/SentimentBadge';
 import { CallDetailDrawer } from '@/components/CallDetailDrawer';
-import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Checkbox } from '@/components/ui/checkbox';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from '@/components/ui/sheet';
 import { toast } from '@/hooks/use-toast';
-import { AlertTriangle, CheckCircle, User, Clock, Eye } from 'lucide-react';
+import { AlertTable } from './components/AlertTable';
+import { AlertDetail } from './components/AlertDetail';
 
 export default function AlertsCenter() {
   const { alerts, setAlerts, updateAlert } = useAppStore();
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [severityFilter, setSeverityFilter] = useState<string>('all');
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const [detailAlert, setDetailAlert] = useState<typeof alerts[0] | null>(null);
+  const [detailAlert, setDetailAlert] = useState<(typeof alerts)[0] | null>(null);
   const [callDrawerOpen, setCallDrawerOpen] = useState(false);
   const [selectedCall, setSelectedCall] = useState<Call | null>(null);
 
-  // Initialize alerts from mock data if empty
   useEffect(() => {
     if (alerts.length === 0) {
       setAlerts(mockData.alerts);
     }
   }, [alerts.length, setAlerts]);
 
-  const filteredAlerts = alerts.filter((alert) => {
-    if (statusFilter !== 'all' && alert.status !== statusFilter) return false;
-    if (severityFilter !== 'all' && alert.severity !== severityFilter) return false;
-    return true;
-  });
+  const filteredAlerts = useMemo(
+    () =>
+      alerts.filter((alert) => {
+        if (statusFilter !== 'all' && alert.status !== statusFilter) return false;
+        if (severityFilter !== 'all' && alert.severity !== severityFilter) return false;
+        return true;
+      }),
+    [alerts, statusFilter, severityFilter]
+  );
+
+  const callsById = useMemo(
+    () => Object.fromEntries(mockData.calls.map((c) => [c.id, c])),
+    []
+  );
+
+  const openAlertsCount = useMemo(
+    () => alerts.filter((a) => a.status === 'open').length,
+    [alerts]
+  );
 
   const handleSelectAll = (checked: boolean) => {
     if (checked) {
@@ -55,9 +52,9 @@ export default function AlertsCenter() {
 
   const handleSelect = (id: string, checked: boolean) => {
     if (checked) {
-      setSelectedIds([...selectedIds, id]);
+      setSelectedIds((prev) => [...prev, id]);
     } else {
-      setSelectedIds(selectedIds.filter((i) => i !== id));
+      setSelectedIds((prev) => prev.filter((i) => i !== id));
     }
   };
 
@@ -108,211 +105,37 @@ export default function AlertsCenter() {
     }
   };
 
+  const detailCall = detailAlert ? callsById[detailAlert.callId] : undefined;
+
   return (
     <div className="container mx-auto px-6 py-8">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h2 className="text-xl font-semibold">Alerts Center</h2>
-          <p className="text-sm text-muted-foreground">
-            {alerts.filter((a) => a.status === 'open').length} open alerts
-          </p>
-        </div>
-        <div className="flex items-center gap-3">
-          <Select value={statusFilter} onValueChange={setStatusFilter}>
-            <SelectTrigger className="w-32">
-              <SelectValue placeholder="Status" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Status</SelectItem>
-              <SelectItem value="open">Open</SelectItem>
-              <SelectItem value="closed">Closed</SelectItem>
-            </SelectContent>
-          </Select>
-          <Select value={severityFilter} onValueChange={setSeverityFilter}>
-            <SelectTrigger className="w-32">
-              <SelectValue placeholder="Severity" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Severity</SelectItem>
-              <SelectItem value="high">High</SelectItem>
-              <SelectItem value="medium">Medium</SelectItem>
-              <SelectItem value="low">Low</SelectItem>
-            </SelectContent>
-          </Select>
-          {selectedIds.length > 0 && (
-            <Button variant="destructive" size="sm" onClick={handleCloseSelected}>
-              Close Selected ({selectedIds.length})
-            </Button>
-          )}
-        </div>
-      </div>
+      <AlertTable
+        alerts={filteredAlerts}
+        callsById={callsById}
+        statusFilter={statusFilter}
+        severityFilter={severityFilter}
+        selectedIds={selectedIds}
+        openAlertsCount={openAlertsCount}
+        onStatusFilterChange={setStatusFilter}
+        onSeverityFilterChange={setSeverityFilter}
+        onSelectAll={handleSelectAll}
+        onSelectRow={handleSelect}
+        onOpenDetail={setDetailAlert}
+        onOpenCall={openCallDetail}
+        onCloseSelected={handleCloseSelected}
+        severityClassName={severityColor}
+      />
 
-      <Card>
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead className="border-b">
-              <tr className="text-left">
-                <th className="p-4 w-12">
-                  <Checkbox
-                    checked={selectedIds.length === filteredAlerts.length && filteredAlerts.length > 0}
-                    onCheckedChange={handleSelectAll}
-                  />
-                </th>
-                <th className="p-4 text-sm font-medium text-muted-foreground">Severity</th>
-                <th className="p-4 text-sm font-medium text-muted-foreground">Rule</th>
-                <th className="p-4 text-sm font-medium text-muted-foreground">Issue</th>
-                <th className="p-4 text-sm font-medium text-muted-foreground">Agent</th>
-                <th className="p-4 text-sm font-medium text-muted-foreground">Created</th>
-                <th className="p-4 text-sm font-medium text-muted-foreground">Status</th>
-                <th className="p-4 text-sm font-medium text-muted-foreground">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filteredAlerts.map((alert) => {
-                const call = mockData.calls.find((c) => c.id === alert.callId);
-                return (
-                  <tr
-                    key={alert.id}
-                    className="border-b hover:bg-muted/50 cursor-pointer"
-                    onClick={() => setDetailAlert(alert)}
-                  >
-                    <td className="p-4" onClick={(e) => e.stopPropagation()}>
-                      <Checkbox
-                        checked={selectedIds.includes(alert.id)}
-                        onCheckedChange={(checked) => handleSelect(alert.id, checked as boolean)}
-                      />
-                    </td>
-                    <td className="p-4">
-                      <Badge className={severityColor(alert.severity)} variant="secondary">
-                        {alert.severity}
-                      </Badge>
-                    </td>
-                    <td className="p-4">
-                      <span className="font-medium">{alert.ruleLabel}</span>
-                    </td>
-                    <td className="p-4">
-                      <span className="text-sm text-muted-foreground">{alert.issue}</span>
-                    </td>
-                    <td className="p-4">
-                      <span className="text-sm">{call?.agentName || 'Unknown'}</span>
-                    </td>
-                    <td className="p-4">
-                      <span className="text-sm text-muted-foreground">
-                        {new Date(alert.createdAt).toLocaleDateString()}
-                      </span>
-                    </td>
-                    <td className="p-4">
-                      <Badge variant={alert.status === 'open' ? 'default' : 'secondary'}>
-                        {alert.status}
-                      </Badge>
-                    </td>
-                    <td className="p-4" onClick={(e) => e.stopPropagation()}>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={() => openCallDetail(alert.callId)}
-                      >
-                        <Eye className="h-4 w-4" />
-                      </Button>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-          {filteredAlerts.length === 0 && (
-            <div className="p-8 text-center text-muted-foreground">
-              No alerts match your filters.
-            </div>
-          )}
-        </div>
-      </Card>
+      <AlertDetail
+        alert={detailAlert}
+        call={detailCall}
+        onClose={() => setDetailAlert(null)}
+        onOpenCall={openCallDetail}
+        onCloseAlert={handleCloseAlert}
+        onReopenAlert={handleReopenAlert}
+        severityClassName={severityColor}
+      />
 
-      {/* Alert Detail Sheet */}
-      <Sheet open={!!detailAlert} onOpenChange={() => setDetailAlert(null)}>
-        <SheetContent>
-          <SheetHeader>
-            <SheetTitle className="flex items-center gap-2">
-              <AlertTriangle className="h-5 w-5" />
-              Alert Details
-            </SheetTitle>
-          </SheetHeader>
-          {detailAlert && (
-            <div className="mt-6 space-y-6">
-              <div className="flex items-center gap-2">
-                <Badge className={severityColor(detailAlert.severity)} variant="secondary">
-                  {detailAlert.severity} severity
-                </Badge>
-                <Badge variant={detailAlert.status === 'open' ? 'default' : 'secondary'}>
-                  {detailAlert.status}
-                </Badge>
-              </div>
-
-              <div>
-                <h4 className="font-semibold mb-1">{detailAlert.ruleLabel}</h4>
-                <p className="text-sm text-muted-foreground">{detailAlert.issue}</p>
-              </div>
-
-              {(() => {
-                const call = mockData.calls.find((c) => c.id === detailAlert.callId);
-                if (!call) return null;
-                return (
-                  <div className="p-4 bg-muted/50 rounded-lg space-y-3">
-                    <h5 className="text-sm font-medium">Call Information</h5>
-                    <div className="grid grid-cols-2 gap-3 text-sm">
-                      <div className="flex items-center gap-2">
-                        <User className="h-4 w-4 text-muted-foreground" />
-                        {call.agentName}
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Clock className="h-4 w-4 text-muted-foreground" />
-                        {Math.floor(call.durationSec / 60)}m {call.durationSec % 60}s
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <span className="text-muted-foreground">Sentiment:</span>
-                      <SentimentBadge sentiment={call.sentimentLabel} />
-                    </div>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-full"
-                      onClick={() => {
-                        openCallDetail(call.id);
-                        setDetailAlert(null);
-                      }}
-                    >
-                      View Full Call Details
-                    </Button>
-                  </div>
-                );
-              })()}
-
-              <div className="flex gap-2">
-                {detailAlert.status === 'open' ? (
-                  <Button
-                    className="flex-1"
-                    onClick={() => handleCloseAlert(detailAlert.id)}
-                  >
-                    <CheckCircle className="h-4 w-4 mr-2" />
-                    Close Alert
-                  </Button>
-                ) : (
-                  <Button
-                    variant="outline"
-                    className="flex-1"
-                    onClick={() => handleReopenAlert(detailAlert.id)}
-                  >
-                    Reopen Alert
-                  </Button>
-                )}
-              </div>
-            </div>
-          )}
-        </SheetContent>
-      </Sheet>
-
-      {/* Call Detail Drawer */}
       <CallDetailDrawer
         call={selectedCall}
         open={callDrawerOpen}

--- a/frontend/src/pages/supervisor/Briefs.tsx
+++ b/frontend/src/pages/supervisor/Briefs.tsx
@@ -1,70 +1,58 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useAppStore } from '@/stores/app-store';
 import { MockService } from '@/lib/mock-service';
-import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
 import { toast } from '@/hooks/use-toast';
-import {
-  FileText,
-  Download,
-  Mail,
-  Calendar,
-  TrendingUp,
-  TrendingDown,
-  AlertTriangle,
-  Star,
-  Plus,
-  Loader2,
-} from 'lucide-react';
+import { BriefGenerator } from './components/BriefGenerator';
+import { BriefList } from './components/BriefList';
+import type { DailyBrief } from './components/BriefList';
+import { BriefDetail } from './components/BriefDetail';
 
 export default function DailyBriefs() {
   const { dailyBriefs } = useAppStore();
   const [selectedDate, setSelectedDate] = useState(
     new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().split('T')[0]
   );
-  const [viewBrief, setViewBrief] = useState<typeof dailyBriefs[0] | null>(null);
+  const [viewBrief, setViewBrief] = useState<DailyBrief | null>(null);
   const [generating, setGenerating] = useState(false);
   const [exporting, setExporting] = useState(false);
+
+  const maxDate = new Date().toISOString().split('T')[0];
+
+  const sortedBriefs = useMemo(
+    () =>
+      [...dailyBriefs].sort(
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+      ) as DailyBrief[],
+    [dailyBriefs]
+  );
 
   const handleGenerate = async () => {
     setGenerating(true);
     try {
-      await new Promise((r) => setTimeout(r, 500)); // Simulate delay
+      await new Promise((r) => setTimeout(r, 500));
       MockService.generateDailyBrief(selectedDate);
       toast({
         title: 'Brief Generated',
         description: `Daily brief for ${selectedDate} has been created.`,
       });
-      // Find the newly created brief
       const newBrief = useAppStore.getState().dailyBriefs.find(
         (b) => b.date === selectedDate
-      );
+      ) as DailyBrief | undefined;
       if (newBrief) setViewBrief(newBrief);
     } finally {
       setGenerating(false);
     }
   };
 
-  const handleExportPDF = async (brief: typeof dailyBriefs[0]) => {
+  const handleExportPDF = async (brief: DailyBrief) => {
     setExporting(true);
     try {
-      // Try to export using html2canvas if the element exists
       await MockService.exportPDF('brief-content', `daily-brief-${brief.date}`);
       toast({
         title: 'PDF Exported',
         description: 'The daily brief has been downloaded as PDF.',
       });
-    } catch (error) {
-      // Fallback to text-based export
+    } catch {
       const content = `
 Daily Brief - ${brief.date}
 Generated: ${new Date(brief.generatedAt).toLocaleString()}
@@ -99,7 +87,7 @@ ${brief.content.exemplarLinks.join(', ')}
     }
   };
 
-  const handleEmailBrief = (brief: typeof dailyBriefs[0]) => {
+  const handleEmailBrief = (brief: DailyBrief) => {
     const result = MockService.sendEmailMock(
       'leadership@demo.com',
       `Daily Brief - ${brief.date}`,
@@ -111,229 +99,29 @@ ${brief.content.exemplarLinks.join(', ')}
     });
   };
 
-  const sortedBriefs = [...dailyBriefs].sort(
-    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-  );
-
   return (
     <div className="container mx-auto px-6 py-8">
-      {/* Generate Brief */}
-      <Card className="p-6 mb-8">
-        <h2 className="text-lg font-semibold mb-4">Generate Daily Brief</h2>
-        <div className="flex items-end gap-4">
-          <div className="space-y-2">
-            <Label>Select Date</Label>
-            <Input
-              type="date"
-              value={selectedDate}
-              onChange={(e) => setSelectedDate(e.target.value)}
-              max={new Date().toISOString().split('T')[0]}
-            />
-          </div>
-          <Button onClick={handleGenerate} disabled={generating}>
-            {generating ? (
-              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-            ) : (
-              <Plus className="h-4 w-4 mr-2" />
-            )}
-            {generating ? 'Generating...' : 'Generate Brief'}
-          </Button>
-        </div>
-      </Card>
+      <BriefGenerator
+        selectedDate={selectedDate}
+        generating={generating}
+        maxDate={maxDate}
+        onDateChange={setSelectedDate}
+        onGenerate={handleGenerate}
+      />
 
-      {/* Briefs List */}
-      <div className="space-y-4">
-        <h2 className="text-lg font-semibold">Generated Briefs</h2>
-        {sortedBriefs.length === 0 ? (
-          <Card className="p-8 text-center">
-            <FileText className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
-            <h3 className="text-lg font-semibold mb-2">No Briefs Yet</h3>
-            <p className="text-muted-foreground">
-              Generate your first daily brief using the form above.
-            </p>
-          </Card>
-        ) : (
-          <div className="grid gap-4">
-            {sortedBriefs.map((brief) => (
-              <Card
-                key={brief.id}
-                className="p-4 hover:bg-muted/50 cursor-pointer transition-colors"
-                onClick={() => setViewBrief(brief)}
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-4">
-                    <div className="p-3 bg-primary/10 rounded-lg">
-                      <FileText className="h-6 w-6 text-primary" />
-                    </div>
-                    <div>
-                      <h3 className="font-semibold flex items-center gap-2">
-                        <Calendar className="h-4 w-4" />
-                        {new Date(brief.date).toLocaleDateString('en-US', {
-                          weekday: 'long',
-                          year: 'numeric',
-                          month: 'long',
-                          day: 'numeric',
-                        })}
-                      </h3>
-                      <p className="text-sm text-muted-foreground">
-                        Generated {new Date(brief.generatedAt).toLocaleString()}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-4">
-                    <div className="text-right">
-                      <p className="text-lg font-semibold">{brief.content.totalCalls}</p>
-                      <p className="text-xs text-muted-foreground">calls</p>
-                    </div>
-                    <div className="text-right">
-                      <p
-                        className={`text-lg font-semibold flex items-center gap-1 ${
-                          brief.content.deltaVsPrior > 0 ? 'text-success' : 'text-destructive'
-                        }`}
-                      >
-                        {brief.content.deltaVsPrior > 0 ? (
-                          <TrendingUp className="h-4 w-4" />
-                        ) : (
-                          <TrendingDown className="h-4 w-4" />
-                        )}
-                        {brief.content.deltaVsPrior > 0 ? '+' : ''}
-                        {brief.content.deltaVsPrior}
-                      </p>
-                      <p className="text-xs text-muted-foreground">vs avg</p>
-                    </div>
-                  </div>
-                </div>
-              </Card>
-            ))}
-          </div>
-        )}
-      </div>
+      <BriefList
+        briefs={sortedBriefs}
+        onSelectBrief={setViewBrief}
+      />
 
-      {/* Brief Detail Dialog */}
-      <Dialog open={!!viewBrief} onOpenChange={() => setViewBrief(null)}>
-        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <FileText className="h-5 w-5" />
-              Daily Brief - {viewBrief?.date}
-            </DialogTitle>
-          </DialogHeader>
-          {viewBrief && (
-            <div className="space-y-6">
-              {/* Brief Content - with ID for PDF export */}
-              <div id="brief-content" className="space-y-6 bg-background p-4 rounded-lg">
-                {/* Summary Stats */}
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                  <Card className="p-4 text-center">
-                    <p className="text-2xl font-bold">{viewBrief.content.totalCalls}</p>
-                    <p className="text-xs text-muted-foreground">Total Calls</p>
-                  </Card>
-                  <Card className="p-4 text-center">
-                    <p className="text-2xl font-bold">{viewBrief.content.avgSentiment}</p>
-                    <p className="text-xs text-muted-foreground">Avg Sentiment</p>
-                  </Card>
-                  <Card className="p-4 text-center">
-                    <p className="text-2xl font-bold">{viewBrief.content.negativePercent}%</p>
-                    <p className="text-xs text-muted-foreground">Negative</p>
-                  </Card>
-                  <Card className="p-4 text-center">
-                    <p
-                      className={`text-2xl font-bold ${
-                        viewBrief.content.deltaVsPrior > 0 ? 'text-success' : 'text-destructive'
-                      }`}
-                    >
-                      {viewBrief.content.deltaVsPrior > 0 ? '+' : ''}
-                      {viewBrief.content.deltaVsPrior}
-                    </p>
-                    <p className="text-xs text-muted-foreground">Delta</p>
-                  </Card>
-                </div>
-
-                {/* Top Issues */}
-                <div>
-                  <h4 className="font-semibold flex items-center gap-2 mb-3">
-                    <AlertTriangle className="h-4 w-4" />
-                    Top Issues
-                  </h4>
-                  <div className="space-y-2">
-                    {viewBrief.content.topIssues.length > 0 ? (
-                      viewBrief.content.topIssues.map((issue, i) => (
-                        <div key={i} className="flex items-center gap-2">
-                          <Badge variant="outline">{i + 1}</Badge>
-                          <span className="capitalize">{issue.replace(/-/g, ' ')}</span>
-                        </div>
-                      ))
-                    ) : (
-                      <p className="text-sm text-muted-foreground">No issues recorded</p>
-                    )}
-                  </div>
-                </div>
-
-                {/* Coaching Opportunities */}
-                <div>
-                  <h4 className="font-semibold flex items-center gap-2 mb-3">
-                    <TrendingUp className="h-4 w-4" />
-                    Coaching Opportunities
-                  </h4>
-                  <div className="space-y-2">
-                    {viewBrief.content.coachingOpportunities.length > 0 ? (
-                      viewBrief.content.coachingOpportunities.map((opp, i) => (
-                        <div key={i} className="p-3 bg-muted/50 rounded-lg text-sm">
-                          {opp}
-                        </div>
-                      ))
-                    ) : (
-                      <p className="text-sm text-muted-foreground">No coaching opportunities identified</p>
-                    )}
-                  </div>
-                </div>
-
-                {/* Exemplar Links */}
-                <div>
-                  <h4 className="font-semibold flex items-center gap-2 mb-3">
-                    <Star className="h-4 w-4" />
-                    Exemplar Calls
-                  </h4>
-                  <div className="flex flex-wrap gap-2">
-                    {viewBrief.content.exemplarLinks.length > 0 ? (
-                      viewBrief.content.exemplarLinks.map((callId) => (
-                        <Badge key={callId} variant="secondary">
-                          {callId}
-                        </Badge>
-                      ))
-                    ) : (
-                      <p className="text-sm text-muted-foreground">No exemplar calls for this period</p>
-                    )}
-                  </div>
-                </div>
-              </div>
-
-              {/* Actions */}
-              <div className="flex gap-2 pt-4 border-t">
-                <Button
-                  variant="outline"
-                  onClick={() => handleExportPDF(viewBrief)}
-                  disabled={exporting}
-                >
-                  {exporting ? (
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                  ) : (
-                    <Download className="h-4 w-4 mr-2" />
-                  )}
-                  Export PDF
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => handleEmailBrief(viewBrief)}
-                >
-                  <Mail className="h-4 w-4 mr-2" />
-                  Email Brief
-                </Button>
-              </div>
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
+      <BriefDetail
+        brief={viewBrief}
+        open={!!viewBrief}
+        exporting={exporting}
+        onOpenChange={(open) => !open && setViewBrief(null)}
+        onExportPDF={handleExportPDF}
+        onEmailBrief={handleEmailBrief}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/supervisor/Overview.tsx
+++ b/frontend/src/pages/supervisor/Overview.tsx
@@ -1,12 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { mockData } from '@/lib/mock-data';
 import { useAppStore } from '@/stores/app-store';
-import { StatCard } from '@/components/StatCard';
-import { SentimentBadge } from '@/components/SentimentBadge';
-import { Card } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Select,
@@ -15,37 +10,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import {
-  TrendingUp,
-  AlertTriangle,
-  Phone,
-  Users,
-  Clock,
-  ArrowUpRight,
-} from 'lucide-react';
-import {
-  LineChart,
-  Line,
-  BarChart,
-  Bar,
-  AreaChart,
-  Area,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  PieChart,
-  Pie,
-  Cell,
-} from 'recharts';
+import { OverviewStats } from './components/OverviewStats';
+import { SentimentTrendChart } from './components/SentimentTrendChart';
+import { CallVolumeChart } from './components/CallVolumeChart';
+import { TopicDistribution } from './components/TopicDistribution';
+import { AgentPerformance } from './components/AgentPerformance';
+import { RecentAlerts } from './components/RecentAlerts';
 
 export default function SupervisorOverview() {
   const navigate = useNavigate();
   const { alerts, setAlerts } = useAppStore();
-  const [dateRange, setDateRange] = useState('14');
+  const [dateRange, setDateRange] = useState<'7' | '14' | '30'>('14');
 
-  // Initialize alerts from mock data if empty
   useEffect(() => {
     if (alerts.length === 0) {
       setAlerts(mockData.alerts);
@@ -53,58 +29,121 @@ export default function SupervisorOverview() {
   }, [alerts.length, setAlerts]);
 
   const { calls, dailyMetrics, agents } = mockData;
-  
-  // Filter by date range
-  const cutoffDate = new Date();
-  cutoffDate.setDate(cutoffDate.getDate() - parseInt(dateRange));
-  const filteredCalls = calls.filter(c => new Date(c.startedAt) >= cutoffDate);
-  const filteredMetrics = dailyMetrics.filter(m => new Date(m.date) >= cutoffDate);
 
-  // Calculate overview stats
-  const avgSentiment = filteredCalls.reduce((sum, c) => sum + c.sentimentScore, 0) / filteredCalls.length;
-  const negativePercent = (filteredCalls.filter(c => c.sentimentLabel === 'negative').length / filteredCalls.length) * 100;
-  const openAlerts = alerts.filter(a => a.status === 'open').length;
+  const cutoffDate = useMemo(() => {
+    const d = new Date();
+    d.setDate(d.getDate() - parseInt(dateRange));
+    return d;
+  }, [dateRange]);
 
-  // Topic distribution
-  const topicCounts: Record<string, number> = {};
-  filteredCalls.forEach(call => {
-    call.topics.forEach(topic => {
-      topicCounts[topic] = (topicCounts[topic] || 0) + 1;
+  const filteredCalls = useMemo(
+    () => calls.filter((c) => new Date(c.startedAt) >= cutoffDate),
+    [calls, cutoffDate]
+  );
+
+  const filteredMetrics = useMemo(
+    () => dailyMetrics.filter((m) => new Date(m.date) >= cutoffDate),
+    [dailyMetrics, cutoffDate]
+  );
+
+  const avgSentiment = useMemo(
+    () =>
+      filteredCalls.length > 0
+        ? filteredCalls.reduce((sum, c) => sum + c.sentimentScore, 0) / filteredCalls.length
+        : 0,
+    [filteredCalls]
+  );
+
+  const negativeCallCount = useMemo(
+    () => filteredCalls.filter((c) => c.sentimentLabel === 'negative').length,
+    [filteredCalls]
+  );
+
+  const negativePercent = useMemo(
+    () =>
+      filteredCalls.length > 0 ? (negativeCallCount / filteredCalls.length) * 100 : 0,
+    [filteredCalls.length, negativeCallCount]
+  );
+
+  const openAlerts = useMemo(
+    () => alerts.filter((a) => a.status === 'open').length,
+    [alerts]
+  );
+
+  const topicCounts = useMemo(() => {
+    const counts: Record<string, number> = {};
+    filteredCalls.forEach((call) => {
+      call.topics.forEach((topic) => {
+        counts[topic] = (counts[topic] || 0) + 1;
+      });
     });
-  });
-  const topTopics = Object.entries(topicCounts)
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, 8)
-    .map(([name, value]) => ({ name: name.replace(/-/g, ' '), value }));
+    return counts;
+  }, [filteredCalls]);
 
-  // Sentiment distribution
-  const sentimentDist = [
-    { name: 'Positive', value: filteredCalls.filter(c => c.sentimentLabel === 'positive').length, color: 'hsl(var(--success))' },
-    { name: 'Neutral', value: filteredCalls.filter(c => c.sentimentLabel === 'neutral').length, color: 'hsl(var(--muted-foreground))' },
-    { name: 'Negative', value: filteredCalls.filter(c => c.sentimentLabel === 'negative').length, color: 'hsl(var(--destructive))' },
-  ];
+  const topTopics = useMemo(
+    () =>
+      Object.entries(topicCounts)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 8)
+        .map(([name, value]) => ({ name: name.replace(/-/g, ' '), value })),
+    [topicCounts]
+  );
 
-  // Agent performance
-  const agentStats = agents.slice(0, 6).map(agent => {
-    const agentCalls = filteredCalls.filter(c => c.agentId === agent.id);
-    const avgSent = agentCalls.length > 0
-      ? agentCalls.reduce((sum, c) => sum + c.sentimentScore, 0) / agentCalls.length
-      : 0;
-    return {
-      name: agent.name.split(' ')[0],
-      sentiment: parseFloat(avgSent.toFixed(2)),
-      calls: agentCalls.length,
-    };
-  }).sort((a, b) => b.sentiment - a.sentiment);
+  const sentimentDist = useMemo(
+    () => [
+      {
+        name: 'Positive' as const,
+        value: filteredCalls.filter((c) => c.sentimentLabel === 'positive').length,
+        color: 'hsl(var(--success))',
+      },
+      {
+        name: 'Neutral' as const,
+        value: filteredCalls.filter((c) => c.sentimentLabel === 'neutral').length,
+        color: 'hsl(var(--muted-foreground))',
+      },
+      {
+        name: 'Negative' as const,
+        value: filteredCalls.filter((c) => c.sentimentLabel === 'negative').length,
+        color: 'hsl(var(--destructive))',
+      },
+    ],
+    [filteredCalls]
+  );
 
-  // Recent alerts
-  const recentAlerts = alerts.filter(a => a.status === 'open').slice(0, 5);
+  const agentStats = useMemo(
+    () =>
+      agents
+        .slice(0, 6)
+        .map((agent) => {
+          const agentCalls = filteredCalls.filter((c) => c.agentId === agent.id);
+          const avgSent =
+            agentCalls.length > 0
+              ? agentCalls.reduce((sum, c) => sum + c.sentimentScore, 0) / agentCalls.length
+              : 0;
+          return {
+            name: agent.name.split(' ')[0],
+            sentiment: parseFloat(avgSent.toFixed(2)),
+            calls: agentCalls.length,
+          };
+        })
+        .sort((a, b) => b.sentiment - a.sentiment),
+    [agents, filteredCalls]
+  );
+
+  const recentAlerts = useMemo(
+    () => alerts.filter((a) => a.status === 'open').slice(0, 5),
+    [alerts]
+  );
+
+  const callsById = useMemo(
+    () => Object.fromEntries(calls.map((c) => [c.id, c])),
+    [calls]
+  );
 
   return (
     <div className="container mx-auto px-6 py-8">
-      {/* Date Range Selector */}
       <div className="flex justify-end mb-6">
-        <Select value={dateRange} onValueChange={setDateRange}>
+        <Select value={dateRange} onValueChange={(v) => setDateRange(v as '7' | '14' | '30')}>
           <SelectTrigger className="w-40">
             <SelectValue placeholder="Select range" />
           </SelectTrigger>
@@ -116,37 +155,15 @@ export default function SupervisorOverview() {
         </Select>
       </div>
 
-      {/* Key Metrics */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-        <StatCard
-          title="Average Sentiment"
-          value={avgSentiment.toFixed(2)}
-          subtitle={`Across ${filteredCalls.length} calls`}
-          icon={TrendingUp}
-          variant={avgSentiment > 0.3 ? 'success' : avgSentiment < -0.2 ? 'destructive' : 'default'}
-        />
-        <StatCard
-          title="Call Volume"
-          value={filteredCalls.length}
-          subtitle={`Last ${dateRange} days`}
-          icon={Phone}
-          variant="default"
-        />
-        <StatCard
-          title="Negative Calls"
-          value={`${negativePercent.toFixed(1)}%`}
-          subtitle={`${filteredCalls.filter(c => c.sentimentLabel === 'negative').length} calls`}
-          icon={AlertTriangle}
-          variant="warning"
-        />
-        <StatCard
-          title="Open Alerts"
-          value={openAlerts}
-          subtitle={`${alerts.length} total alerts`}
-          icon={AlertTriangle}
-          variant={openAlerts > 10 ? 'destructive' : 'warning'}
-        />
-      </div>
+      <OverviewStats
+        avgSentiment={avgSentiment}
+        filteredCallCount={filteredCalls.length}
+        dateRange={dateRange}
+        negativePercent={negativePercent}
+        negativeCallCount={negativeCallCount}
+        openAlerts={openAlerts}
+        totalAlerts={alerts.length}
+      />
 
       <Tabs defaultValue="trends" className="space-y-6">
         <TabsList>
@@ -156,218 +173,25 @@ export default function SupervisorOverview() {
         </TabsList>
 
         <TabsContent value="trends" className="space-y-6">
-          <Card className="p-6">
-            <div className="flex items-center justify-between mb-6">
-              <div>
-                <h3 className="text-lg font-semibold">Sentiment Trend</h3>
-                <p className="text-sm text-muted-foreground">Daily average sentiment scores</p>
-              </div>
-            </div>
-            <ResponsiveContainer width="100%" height={300}>
-              <AreaChart data={filteredMetrics}>
-                <defs>
-                  <linearGradient id="sentimentGradient" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="hsl(var(--primary))" stopOpacity={0.3} />
-                    <stop offset="95%" stopColor="hsl(var(--primary))" stopOpacity={0} />
-                  </linearGradient>
-                </defs>
-                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-                <XAxis
-                  dataKey="date"
-                  stroke="hsl(var(--muted-foreground))"
-                  fontSize={12}
-                  tickFormatter={(date) => new Date(date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
-                />
-                <YAxis stroke="hsl(var(--muted-foreground))" fontSize={12} domain={[-1, 1]} />
-                <Tooltip
-                  contentStyle={{
-                    backgroundColor: 'hsl(var(--card))',
-                    border: '1px solid hsl(var(--border))',
-                    borderRadius: '8px',
-                  }}
-                />
-                <Area
-                  type="monotone"
-                  dataKey="avgSentiment"
-                  stroke="hsl(var(--primary))"
-                  strokeWidth={2}
-                  fill="url(#sentimentGradient)"
-                />
-              </AreaChart>
-            </ResponsiveContainer>
-          </Card>
-
-          <Card className="p-6">
-            <h3 className="text-lg font-semibold mb-6">Call Volume</h3>
-            <ResponsiveContainer width="100%" height={250}>
-              <LineChart data={filteredMetrics}>
-                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-                <XAxis
-                  dataKey="date"
-                  stroke="hsl(var(--muted-foreground))"
-                  fontSize={12}
-                  tickFormatter={(date) => new Date(date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
-                />
-                <YAxis stroke="hsl(var(--muted-foreground))" fontSize={12} />
-                <Tooltip
-                  contentStyle={{
-                    backgroundColor: 'hsl(var(--card))',
-                    border: '1px solid hsl(var(--border))',
-                    borderRadius: '8px',
-                  }}
-                />
-                <Line type="monotone" dataKey="callCount" stroke="hsl(var(--accent))" strokeWidth={2} dot={{ fill: 'hsl(var(--accent))' }} />
-              </LineChart>
-            </ResponsiveContainer>
-          </Card>
+          <SentimentTrendChart data={filteredMetrics} />
+          <CallVolumeChart data={filteredMetrics} />
         </TabsContent>
 
         <TabsContent value="topics" className="space-y-6">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card className="p-6">
-              <h3 className="text-lg font-semibold mb-6">Top Call Topics</h3>
-              <ResponsiveContainer width="100%" height={350}>
-                <BarChart data={topTopics} layout="vertical">
-                  <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-                  <XAxis type="number" stroke="hsl(var(--muted-foreground))" fontSize={12} />
-                  <YAxis type="category" dataKey="name" stroke="hsl(var(--muted-foreground))" fontSize={12} width={120} />
-                  <Tooltip
-                    contentStyle={{
-                      backgroundColor: 'hsl(var(--card))',
-                      border: '1px solid hsl(var(--border))',
-                      borderRadius: '8px',
-                    }}
-                  />
-                  <Bar dataKey="value" fill="hsl(var(--primary))" radius={[0, 8, 8, 0]} />
-                </BarChart>
-              </ResponsiveContainer>
-            </Card>
-
-            <Card className="p-6">
-              <h3 className="text-lg font-semibold mb-6">Sentiment Distribution</h3>
-              <ResponsiveContainer width="100%" height={350}>
-                <PieChart>
-                  <Pie
-                    data={sentimentDist}
-                    cx="50%"
-                    cy="50%"
-                    labelLine={false}
-                    label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
-                    outerRadius={120}
-                    dataKey="value"
-                  >
-                    {sentimentDist.map((entry, index) => (
-                      <Cell key={`cell-${index}`} fill={entry.color} />
-                    ))}
-                  </Pie>
-                  <Tooltip
-                    contentStyle={{
-                      backgroundColor: 'hsl(var(--card))',
-                      border: '1px solid hsl(var(--border))',
-                      borderRadius: '8px',
-                    }}
-                  />
-                </PieChart>
-              </ResponsiveContainer>
-            </Card>
-          </div>
+          <TopicDistribution topTopics={topTopics} sentimentDist={sentimentDist} />
         </TabsContent>
 
         <TabsContent value="agents">
-          <Card className="p-6">
-            <h3 className="text-lg font-semibold mb-6">Agent Performance</h3>
-            <ResponsiveContainer width="100%" height={350}>
-              <BarChart data={agentStats}>
-                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-                <XAxis dataKey="name" stroke="hsl(var(--muted-foreground))" fontSize={12} />
-                <YAxis stroke="hsl(var(--muted-foreground))" fontSize={12} domain={[-1, 1]} />
-                <Tooltip
-                  contentStyle={{
-                    backgroundColor: 'hsl(var(--card))',
-                    border: '1px solid hsl(var(--border))',
-                    borderRadius: '8px',
-                  }}
-                />
-                <Bar dataKey="sentiment" fill="hsl(var(--primary))" radius={[8, 8, 0, 0]} />
-              </BarChart>
-            </ResponsiveContainer>
-          </Card>
+          <AgentPerformance data={agentStats} />
         </TabsContent>
       </Tabs>
 
-      {/* Recent Alerts */}
-      <Card className="mt-8 p-6">
-        <div className="flex items-center justify-between mb-6">
-          <div>
-            <h3 className="text-lg font-semibold">Recent Alerts</h3>
-            <p className="text-sm text-muted-foreground">High-priority issues requiring attention</p>
-          </div>
-          <Button variant="outline" size="sm" onClick={() => navigate('/supervisor/alerts')}>
-            View All
-            <ArrowUpRight className="h-4 w-4 ml-2" />
-          </Button>
-        </div>
-        <div className="space-y-4">
-          {recentAlerts.length === 0 ? (
-            <p className="text-muted-foreground text-center py-8">No open alerts</p>
-          ) : (
-            recentAlerts.map((alert) => {
-              const call = calls.find((c) => c.id === alert.callId);
-              return (
-                <div
-                  key={alert.id}
-                  className="flex items-center justify-between p-4 rounded-lg border bg-card/50 hover:bg-card transition-colors cursor-pointer"
-                  onClick={() => navigate('/supervisor/alerts')}
-                >
-                  <div className="flex items-start gap-4 flex-1">
-                    <div
-                      className={`p-2 rounded-lg ${
-                        alert.severity === 'high'
-                          ? 'bg-destructive/10'
-                          : alert.severity === 'medium'
-                          ? 'bg-warning/10'
-                          : 'bg-muted'
-                      }`}
-                    >
-                      <AlertTriangle
-                        className={`h-5 w-5 ${
-                          alert.severity === 'high'
-                            ? 'text-destructive'
-                            : alert.severity === 'medium'
-                            ? 'text-warning'
-                            : 'text-muted-foreground'
-                        }`}
-                      />
-                    </div>
-                    <div className="flex-1">
-                      <div className="flex items-center gap-2 mb-1">
-                        <h4 className="font-semibold">{alert.ruleLabel}</h4>
-                        <Badge variant="outline" className="text-xs">
-                          {alert.severity}
-                        </Badge>
-                      </div>
-                      <p className="text-sm text-muted-foreground mb-2">{alert.issue}</p>
-                      {call && (
-                        <div className="flex items-center gap-4 text-xs text-muted-foreground">
-                          <span className="flex items-center gap-1">
-                            <Users className="h-3 w-3" />
-                            {call.agentName}
-                          </span>
-                          <span className="flex items-center gap-1">
-                            <Clock className="h-3 w-3" />
-                            {new Date(call.startedAt).toLocaleDateString()}
-                          </span>
-                          <SentimentBadge sentiment={call.sentimentLabel} />
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              );
-            })
-          )}
-        </div>
-      </Card>
+      <RecentAlerts
+        alerts={recentAlerts}
+        callsById={callsById}
+        onViewAll={() => navigate('/supervisor/alerts')}
+        onAlertClick={() => navigate('/supervisor/alerts')}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/supervisor/Search.tsx
+++ b/frontend/src/pages/supervisor/Search.tsx
@@ -1,22 +1,13 @@
 import { useState } from 'react';
-import { mockData, Call } from '@/lib/mock-data';
+import { mockData } from '@/lib/mock-data';
+import type { Call } from '@/lib/mock-data';
 import { MockService, SearchResult } from '@/lib/mock-service';
-import { SentimentBadge } from '@/components/SentimentBadge';
 import { CallDetailDrawer } from '@/components/CallDetailDrawer';
 import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Badge } from '@/components/ui/badge';
-import { Slider } from '@/components/ui/slider';
-import { Checkbox } from '@/components/ui/checkbox';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
 import { toast } from '@/hooks/use-toast';
-import { Search, Download, Clock, User, Loader2, ChevronDown, X } from 'lucide-react';
+import { Search as SearchIcon } from 'lucide-react';
+import { SearchFilters } from './components/SearchFilters';
+import { SearchResults } from './components/SearchResults';
 
 export default function CallSearch() {
   const [keyword, setKeyword] = useState('');
@@ -118,231 +109,49 @@ export default function CallSearch() {
 
   const selectedAgentNames = selectedAgentIds
     .map((id) => mockData.agents.find((a) => a.id === id)?.name)
-    .filter(Boolean);
+    .filter((n): n is string => Boolean(n));
 
   return (
     <div className="container mx-auto px-6 py-8">
-      {/* Search Filters */}
-      <Card className="p-6 mb-6">
-        <h2 className="text-lg font-semibold mb-4">Search Calls</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          <div className="space-y-2">
-            <Label>Keyword</Label>
-            <Input
-              placeholder="Search transcripts, topics..."
-              value={keyword}
-              onChange={(e) => setKeyword(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>Agents</Label>
-            <Popover>
-              <PopoverTrigger asChild>
-                <Button
-                  variant="outline"
-                  className="w-full justify-between font-normal"
-                >
-                  {selectedAgentIds.length === 0 ? (
-                    <span className="text-muted-foreground">Select agents...</span>
-                  ) : (
-                    <span className="truncate">
-                      {selectedAgentIds.length} agent{selectedAgentIds.length !== 1 ? 's' : ''} selected
-                    </span>
-                  )}
-                  <ChevronDown className="h-4 w-4 ml-2 shrink-0 opacity-50" />
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent className="w-64 p-0" align="start">
-                <div className="p-2 border-b">
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm font-medium">Select Agents</span>
-                    {selectedAgentIds.length > 0 && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-auto p-1 text-xs"
-                        onClick={clearAgentSelection}
-                      >
-                        Clear all
-                      </Button>
-                    )}
-                  </div>
-                </div>
-                <div className="max-h-64 overflow-y-auto p-2">
-                  {mockData.agents.map((agent) => (
-                    <label
-                      key={agent.id}
-                      className="flex items-center gap-2 p-2 rounded hover:bg-muted cursor-pointer"
-                    >
-                      <Checkbox
-                        checked={selectedAgentIds.includes(agent.id)}
-                        onCheckedChange={() => handleAgentToggle(agent.id)}
-                      />
-                      <span className="text-sm">{agent.name}</span>
-                      <Badge variant="secondary" className="ml-auto text-xs">
-                        {agent.team}
-                      </Badge>
-                    </label>
-                  ))}
-                </div>
-              </PopoverContent>
-            </Popover>
-            {selectedAgentIds.length > 0 && (
-              <div className="flex flex-wrap gap-1 mt-2">
-                {selectedAgentNames.slice(0, 3).map((name) => (
-                  <Badge key={name} variant="secondary" className="text-xs">
-                    {name}
-                  </Badge>
-                ))}
-                {selectedAgentIds.length > 3 && (
-                  <Badge variant="outline" className="text-xs">
-                    +{selectedAgentIds.length - 3} more
-                  </Badge>
-                )}
-              </div>
-            )}
-          </div>
-          <div className="space-y-2">
-            <Label>
-              Sentiment Range: [{sentimentRange[0].toFixed(1)}, {sentimentRange[1].toFixed(1)}]
-            </Label>
-            <Slider
-              min={-1}
-              max={1}
-              step={0.1}
-              value={sentimentRange}
-              onValueChange={(value) => setSentimentRange(value as [number, number])}
-              className="py-4"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>From Date</Label>
-            <Input
-              type="date"
-              value={dateFrom}
-              onChange={(e) => setDateFrom(e.target.value)}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>To Date</Label>
-            <Input
-              type="date"
-              value={dateTo}
-              onChange={(e) => setDateTo(e.target.value)}
-            />
-          </div>
-          <div className="flex items-end gap-2">
-            <Button onClick={() => handleSearch()} disabled={loading} className="flex-1">
-              {loading ? (
-                <Loader2 className="h-4 w-4 animate-spin mr-2" />
-              ) : (
-                <Search className="h-4 w-4 mr-2" />
-              )}
-              Search
-            </Button>
-            {results && results.calls.length > 0 && (
-              <Button variant="outline" onClick={handleExportCSV}>
-                <Download className="h-4 w-4 mr-2" />
-                CSV
-              </Button>
-            )}
-          </div>
-        </div>
-      </Card>
+      <SearchFilters
+        keyword={keyword}
+        selectedAgentIds={selectedAgentIds}
+        selectedAgentNames={selectedAgentNames}
+        agents={mockData.agents}
+        sentimentRange={sentimentRange}
+        dateFrom={dateFrom}
+        dateTo={dateTo}
+        loading={loading}
+        canExport={!!(results && results.calls.length > 0)}
+        onKeywordChange={setKeyword}
+        onAgentToggle={handleAgentToggle}
+        onClearAgents={clearAgentSelection}
+        onSentimentRangeChange={setSentimentRange}
+        onDateFromChange={setDateFrom}
+        onDateToChange={setDateTo}
+        onSearch={() => handleSearch()}
+        onExportCSV={handleExportCSV}
+      />
 
-      {/* Results */}
       {results && (
-        <div className="space-y-4">
-          <div className="flex items-center justify-between">
-            <p className="text-sm text-muted-foreground">
-              Found {results.total} calls (page {results.page} of {results.totalPages})
-            </p>
-            {results.totalPages > 1 && (
-              <div className="flex gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={results.page <= 1}
-                  onClick={() => handleSearch(results.page - 1)}
-                >
-                  Previous
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={results.page >= results.totalPages}
-                  onClick={() => handleSearch(results.page + 1)}
-                >
-                  Next
-                </Button>
-              </div>
-            )}
-          </div>
-
-          {results.calls.length === 0 ? (
-            <Card className="p-8 text-center">
-              <p className="text-muted-foreground">No calls match your search criteria.</p>
-            </Card>
-          ) : (
-            <div className="space-y-3">
-              {results.calls.map((call) => {
-                const snippet = getSnippet(call);
-                return (
-                  <Card
-                    key={call.id}
-                    className="p-4 hover:bg-muted/50 cursor-pointer transition-colors"
-                    onClick={() => {
-                      setSelectedCall(call);
-                      setDrawerOpen(true);
-                    }}
-                  >
-                    <div className="flex items-start justify-between gap-4">
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-3 mb-2">
-                          <SentimentBadge sentiment={call.sentimentLabel} />
-                          <span className="text-sm text-muted-foreground flex items-center gap-1">
-                            <User className="h-3 w-3" />
-                            {call.agentName}
-                          </span>
-                          <span className="text-sm text-muted-foreground flex items-center gap-1">
-                            <Clock className="h-3 w-3" />
-                            {formatDuration(call.durationSec)}
-                          </span>
-                          <span className="text-sm text-muted-foreground">
-                            {new Date(call.startedAt).toLocaleDateString()}
-                          </span>
-                        </div>
-                        <div className="flex flex-wrap gap-1 mb-2">
-                          {call.topics.map((topic) => (
-                            <Badge key={topic} variant="secondary" className="text-xs">
-                              {highlightKeyword(topic.replace(/-/g, ' '))}
-                            </Badge>
-                          ))}
-                        </div>
-                        {snippet && (
-                          <p className="text-sm text-muted-foreground line-clamp-2">
-                            {highlightKeyword(snippet)}
-                          </p>
-                        )}
-                      </div>
-                      <div className="text-right shrink-0">
-                        <p className="text-lg font-semibold">{call.sentimentScore.toFixed(2)}</p>
-                        <p className="text-xs text-muted-foreground">sentiment</p>
-                      </div>
-                    </div>
-                  </Card>
-                );
-              })}
-            </div>
-          )}
-        </div>
+        <SearchResults
+          results={results}
+          keyword={keyword}
+          loading={loading}
+          onPageChange={handleSearch}
+          onSelectCall={(call) => {
+            setSelectedCall(call);
+            setDrawerOpen(true);
+          }}
+          getSnippet={getSnippet}
+          highlightKeyword={highlightKeyword}
+          formatDuration={formatDuration}
+        />
       )}
 
-      {/* Empty state */}
       {!results && !loading && (
         <Card className="p-12 text-center">
-          <Search className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
+          <SearchIcon className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
           <h3 className="text-lg font-semibold mb-2">Search Calls</h3>
           <p className="text-muted-foreground">
             Use the filters above to search through call transcripts, agents, and topics.

--- a/frontend/src/pages/supervisor/components/AgentPerformance.tsx
+++ b/frontend/src/pages/supervisor/components/AgentPerformance.tsx
@@ -1,0 +1,43 @@
+import { Card } from '@/components/ui/card';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+
+export interface AgentPerformanceDatum {
+  name: string;
+  sentiment: number;
+  calls: number;
+}
+
+export interface AgentPerformanceProps {
+  data: AgentPerformanceDatum[];
+}
+
+export function AgentPerformance({ data }: AgentPerformanceProps) {
+  return (
+    <Card className="p-6">
+      <h3 className="text-lg font-semibold mb-6">Agent Performance</h3>
+      <ResponsiveContainer width="100%" height={350}>
+        <BarChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+          <XAxis dataKey="name" stroke="hsl(var(--muted-foreground))" fontSize={12} />
+          <YAxis stroke="hsl(var(--muted-foreground))" fontSize={12} domain={[-1, 1]} />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: 'hsl(var(--card))',
+              border: '1px solid hsl(var(--border))',
+              borderRadius: '8px',
+            }}
+          />
+          <Bar dataKey="sentiment" fill="hsl(var(--primary))" radius={[8, 8, 0, 0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    </Card>
+  );
+}

--- a/frontend/src/pages/supervisor/components/AlertDetail.tsx
+++ b/frontend/src/pages/supervisor/components/AlertDetail.tsx
@@ -1,0 +1,112 @@
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { SentimentBadge } from '@/components/SentimentBadge';
+import { AlertTriangle, CheckCircle, User, Clock } from 'lucide-react';
+import type { Alert, Call } from '@/lib/mock-data';
+
+export interface AlertDetailProps {
+  alert: Alert | null;
+  call: Call | undefined;
+  onClose: () => void;
+  onOpenCall: (callId: string) => void;
+  onCloseAlert: (id: string) => void;
+  onReopenAlert: (id: string) => void;
+  severityClassName: (severity: string) => string;
+}
+
+export function AlertDetail({
+  alert,
+  call,
+  onClose,
+  onOpenCall,
+  onCloseAlert,
+  onReopenAlert,
+  severityClassName,
+}: AlertDetailProps) {
+  return (
+    <Sheet open={!!alert} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5" />
+            Alert Details
+          </SheetTitle>
+        </SheetHeader>
+        {alert && (
+          <div className="mt-6 space-y-6">
+            <div className="flex items-center gap-2">
+              <Badge className={severityClassName(alert.severity)} variant="secondary">
+                {alert.severity} severity
+              </Badge>
+              <Badge variant={alert.status === 'open' ? 'default' : 'secondary'}>
+                {alert.status}
+              </Badge>
+            </div>
+
+            <div>
+              <h4 className="font-semibold mb-1">{alert.ruleLabel}</h4>
+              <p className="text-sm text-muted-foreground">{alert.issue}</p>
+            </div>
+
+            {call && (
+              <div className="p-4 bg-muted/50 rounded-lg space-y-3">
+                <h5 className="text-sm font-medium">Call Information</h5>
+                <div className="grid grid-cols-2 gap-3 text-sm">
+                  <div className="flex items-center gap-2">
+                    <User className="h-4 w-4 text-muted-foreground" />
+                    {call.agentName}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Clock className="h-4 w-4 text-muted-foreground" />
+                    {Math.floor(call.durationSec / 60)}m {call.durationSec % 60}s
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-muted-foreground">Sentiment:</span>
+                  <SentimentBadge sentiment={call.sentimentLabel} />
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  onClick={() => {
+                    onOpenCall(call.id);
+                    onClose();
+                  }}
+                >
+                  View Full Call Details
+                </Button>
+              </div>
+            )}
+
+            <div className="flex gap-2">
+              {alert.status === 'open' ? (
+                <Button
+                  className="flex-1"
+                  onClick={() => onCloseAlert(alert.id)}
+                >
+                  <CheckCircle className="h-4 w-4 mr-2" />
+                  Close Alert
+                </Button>
+              ) : (
+                <Button
+                  variant="outline"
+                  className="flex-1"
+                  onClick={() => onReopenAlert(alert.id)}
+                >
+                  Reopen Alert
+                </Button>
+              )}
+            </div>
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/pages/supervisor/components/AlertTable.tsx
+++ b/frontend/src/pages/supervisor/components/AlertTable.tsx
@@ -1,0 +1,169 @@
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Eye } from 'lucide-react';
+import type { Alert, Call } from '@/lib/mock-data';
+
+export interface AlertTableProps {
+  alerts: Alert[];
+  callsById: Record<string, Call>;
+  statusFilter: string;
+  severityFilter: string;
+  selectedIds: string[];
+  openAlertsCount: number;
+  onStatusFilterChange: (value: string) => void;
+  onSeverityFilterChange: (value: string) => void;
+  onSelectAll: (checked: boolean) => void;
+  onSelectRow: (id: string, checked: boolean) => void;
+  onOpenDetail: (alert: Alert) => void;
+  onOpenCall: (callId: string) => void;
+  onCloseSelected: () => void;
+  severityClassName: (severity: string) => string;
+}
+
+export function AlertTable({
+  alerts,
+  callsById,
+  statusFilter,
+  severityFilter,
+  selectedIds,
+  openAlertsCount,
+  onStatusFilterChange,
+  onSeverityFilterChange,
+  onSelectAll,
+  onSelectRow,
+  onOpenDetail,
+  onOpenCall,
+  onCloseSelected,
+  severityClassName,
+}: AlertTableProps) {
+  const allSelected = selectedIds.length === alerts.length && alerts.length > 0;
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h2 className="text-xl font-semibold">Alerts Center</h2>
+          <p className="text-sm text-muted-foreground">{openAlertsCount} open alerts</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <Select value={statusFilter} onValueChange={onStatusFilterChange}>
+            <SelectTrigger className="w-32">
+              <SelectValue placeholder="Status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Status</SelectItem>
+              <SelectItem value="open">Open</SelectItem>
+              <SelectItem value="closed">Closed</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={severityFilter} onValueChange={onSeverityFilterChange}>
+            <SelectTrigger className="w-32">
+              <SelectValue placeholder="Severity" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Severity</SelectItem>
+              <SelectItem value="high">High</SelectItem>
+              <SelectItem value="medium">Medium</SelectItem>
+              <SelectItem value="low">Low</SelectItem>
+            </SelectContent>
+          </Select>
+          {selectedIds.length > 0 && (
+            <Button variant="destructive" size="sm" onClick={onCloseSelected}>
+              Close Selected ({selectedIds.length})
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <Card>
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead className="border-b">
+              <tr className="text-left">
+                <th className="p-4 w-12">
+                  <Checkbox
+                    checked={allSelected}
+                    onCheckedChange={onSelectAll}
+                  />
+                </th>
+                <th className="p-4 text-sm font-medium text-muted-foreground">Severity</th>
+                <th className="p-4 text-sm font-medium text-muted-foreground">Rule</th>
+                <th className="p-4 text-sm font-medium text-muted-foreground">Issue</th>
+                <th className="p-4 text-sm font-medium text-muted-foreground">Agent</th>
+                <th className="p-4 text-sm font-medium text-muted-foreground">Created</th>
+                <th className="p-4 text-sm font-medium text-muted-foreground">Status</th>
+                <th className="p-4 text-sm font-medium text-muted-foreground">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {alerts.map((alert) => {
+                const call = callsById[alert.callId];
+                return (
+                  <tr
+                    key={alert.id}
+                    className="border-b hover:bg-muted/50 cursor-pointer"
+                    onClick={() => onOpenDetail(alert)}
+                  >
+                    <td className="p-4" onClick={(e) => e.stopPropagation()}>
+                      <Checkbox
+                        checked={selectedIds.includes(alert.id)}
+                        onCheckedChange={(checked) => onSelectRow(alert.id, checked as boolean)}
+                      />
+                    </td>
+                    <td className="p-4">
+                      <Badge className={severityClassName(alert.severity)} variant="secondary">
+                        {alert.severity}
+                      </Badge>
+                    </td>
+                    <td className="p-4">
+                      <span className="font-medium">{alert.ruleLabel}</span>
+                    </td>
+                    <td className="p-4">
+                      <span className="text-sm text-muted-foreground">{alert.issue}</span>
+                    </td>
+                    <td className="p-4">
+                      <span className="text-sm">{call?.agentName || 'Unknown'}</span>
+                    </td>
+                    <td className="p-4">
+                      <span className="text-sm text-muted-foreground">
+                        {new Date(alert.createdAt).toLocaleDateString()}
+                      </span>
+                    </td>
+                    <td className="p-4">
+                      <Badge variant={alert.status === 'open' ? 'default' : 'secondary'}>
+                        {alert.status}
+                      </Badge>
+                    </td>
+                    <td className="p-4" onClick={(e) => e.stopPropagation()}>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onOpenCall(alert.callId)}
+                      >
+                        <Eye className="h-4 w-4" />
+                      </Button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          {alerts.length === 0 && (
+            <div className="p-8 text-center text-muted-foreground">
+              No alerts match your filters.
+            </div>
+          )}
+        </div>
+      </Card>
+    </>
+  );
+}

--- a/frontend/src/pages/supervisor/components/BriefDetail.tsx
+++ b/frontend/src/pages/supervisor/components/BriefDetail.tsx
@@ -1,0 +1,150 @@
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { FileText, Download, Mail, AlertTriangle, TrendingUp, Star, Loader2 } from 'lucide-react';
+import type { DailyBrief } from './BriefList';
+
+export interface BriefDetailProps {
+  brief: DailyBrief | null;
+  open: boolean;
+  exporting: boolean;
+  onOpenChange: (open: boolean) => void;
+  onExportPDF: (brief: DailyBrief) => void;
+  onEmailBrief: (brief: DailyBrief) => void;
+}
+
+export function BriefDetail({
+  brief,
+  open,
+  exporting,
+  onOpenChange,
+  onExportPDF,
+  onEmailBrief,
+}: BriefDetailProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FileText className="h-5 w-5" />
+            Daily Brief - {brief?.date}
+          </DialogTitle>
+        </DialogHeader>
+        {brief && (
+          <div className="space-y-6">
+            <div id="brief-content" className="space-y-6 bg-background p-4 rounded-lg">
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <Card className="p-4 text-center">
+                  <p className="text-2xl font-bold">{brief.content.totalCalls}</p>
+                  <p className="text-xs text-muted-foreground">Total Calls</p>
+                </Card>
+                <Card className="p-4 text-center">
+                  <p className="text-2xl font-bold">{brief.content.avgSentiment}</p>
+                  <p className="text-xs text-muted-foreground">Avg Sentiment</p>
+                </Card>
+                <Card className="p-4 text-center">
+                  <p className="text-2xl font-bold">{brief.content.negativePercent}%</p>
+                  <p className="text-xs text-muted-foreground">Negative</p>
+                </Card>
+                <Card className="p-4 text-center">
+                  <p
+                    className={`text-2xl font-bold ${
+                      brief.content.deltaVsPrior > 0 ? 'text-success' : 'text-destructive'
+                    }`}
+                  >
+                    {brief.content.deltaVsPrior > 0 ? '+' : ''}
+                    {brief.content.deltaVsPrior}
+                  </p>
+                  <p className="text-xs text-muted-foreground">Delta</p>
+                </Card>
+              </div>
+
+              <div>
+                <h4 className="font-semibold flex items-center gap-2 mb-3">
+                  <AlertTriangle className="h-4 w-4" />
+                  Top Issues
+                </h4>
+                <div className="space-y-2">
+                  {brief.content.topIssues.length > 0 ? (
+                    brief.content.topIssues.map((issue, i) => (
+                      <div key={i} className="flex items-center gap-2">
+                        <Badge variant="outline">{i + 1}</Badge>
+                        <span className="capitalize">{issue.replace(/-/g, ' ')}</span>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="text-sm text-muted-foreground">No issues recorded</p>
+                  )}
+                </div>
+              </div>
+
+              <div>
+                <h4 className="font-semibold flex items-center gap-2 mb-3">
+                  <TrendingUp className="h-4 w-4" />
+                  Coaching Opportunities
+                </h4>
+                <div className="space-y-2">
+                  {brief.content.coachingOpportunities.length > 0 ? (
+                    brief.content.coachingOpportunities.map((opp, i) => (
+                      <div key={i} className="p-3 bg-muted/50 rounded-lg text-sm">
+                        {opp}
+                      </div>
+                    ))
+                  ) : (
+                    <p className="text-sm text-muted-foreground">No coaching opportunities identified</p>
+                  )}
+                </div>
+              </div>
+
+              <div>
+                <h4 className="font-semibold flex items-center gap-2 mb-3">
+                  <Star className="h-4 w-4" />
+                  Exemplar Calls
+                </h4>
+                <div className="flex flex-wrap gap-2">
+                  {brief.content.exemplarLinks.length > 0 ? (
+                    brief.content.exemplarLinks.map((callId) => (
+                      <Badge key={callId} variant="secondary">
+                        {callId}
+                      </Badge>
+                    ))
+                  ) : (
+                    <p className="text-sm text-muted-foreground">No exemplar calls for this period</p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="flex gap-2 pt-4 border-t">
+              <Button
+                variant="outline"
+                onClick={() => onExportPDF(brief)}
+                disabled={exporting}
+              >
+                {exporting ? (
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                ) : (
+                  <Download className="h-4 w-4 mr-2" />
+                )}
+                Export PDF
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => onEmailBrief(brief)}
+              >
+                <Mail className="h-4 w-4 mr-2" />
+                Email Brief
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/pages/supervisor/components/BriefGenerator.tsx
+++ b/frontend/src/pages/supervisor/components/BriefGenerator.tsx
@@ -1,0 +1,46 @@
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Plus, Loader2 } from 'lucide-react';
+
+export interface BriefGeneratorProps {
+  selectedDate: string;
+  generating: boolean;
+  maxDate: string;
+  onDateChange: (value: string) => void;
+  onGenerate: () => void;
+}
+
+export function BriefGenerator({
+  selectedDate,
+  generating,
+  maxDate,
+  onDateChange,
+  onGenerate,
+}: BriefGeneratorProps) {
+  return (
+    <Card className="p-6 mb-8">
+      <h2 className="text-lg font-semibold mb-4">Generate Daily Brief</h2>
+      <div className="flex items-end gap-4">
+        <div className="space-y-2">
+          <Label>Select Date</Label>
+          <Input
+            type="date"
+            value={selectedDate}
+            onChange={(e) => onDateChange(e.target.value)}
+            max={maxDate}
+          />
+        </div>
+        <Button onClick={onGenerate} disabled={generating}>
+          {generating ? (
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+          ) : (
+            <Plus className="h-4 w-4 mr-2" />
+          )}
+          {generating ? 'Generating...' : 'Generate Brief'}
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/pages/supervisor/components/BriefList.tsx
+++ b/frontend/src/pages/supervisor/components/BriefList.tsx
@@ -1,0 +1,93 @@
+import { Card } from '@/components/ui/card';
+import { FileText, Calendar, TrendingUp, TrendingDown } from 'lucide-react';
+
+export interface DailyBrief {
+  id: string;
+  date: string;
+  generatedAt: string;
+  content: {
+    totalCalls: number;
+    avgSentiment: number;
+    negativePercent: number;
+    deltaVsPrior: number;
+    topIssues: string[];
+    coachingOpportunities: string[];
+    exemplarLinks: string[];
+  };
+}
+
+export interface BriefListProps {
+  briefs: DailyBrief[];
+  onSelectBrief: (brief: DailyBrief) => void;
+}
+
+export function BriefList({ briefs, onSelectBrief }: BriefListProps) {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-semibold">Generated Briefs</h2>
+      {briefs.length === 0 ? (
+        <Card className="p-8 text-center">
+          <FileText className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
+          <h3 className="text-lg font-semibold mb-2">No Briefs Yet</h3>
+          <p className="text-muted-foreground">
+            Generate your first daily brief using the form above.
+          </p>
+        </Card>
+      ) : (
+        <div className="grid gap-4">
+          {briefs.map((brief) => (
+            <Card
+              key={brief.id}
+              className="p-4 hover:bg-muted/50 cursor-pointer transition-colors"
+              onClick={() => onSelectBrief(brief)}
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                  <div className="p-3 bg-primary/10 rounded-lg">
+                    <FileText className="h-6 w-6 text-primary" />
+                  </div>
+                  <div>
+                    <h3 className="font-semibold flex items-center gap-2">
+                      <Calendar className="h-4 w-4" />
+                      {new Date(brief.date).toLocaleDateString('en-US', {
+                        weekday: 'long',
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric',
+                      })}
+                    </h3>
+                    <p className="text-sm text-muted-foreground">
+                      Generated {new Date(brief.generatedAt).toLocaleString()}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-4">
+                  <div className="text-right">
+                    <p className="text-lg font-semibold">{brief.content.totalCalls}</p>
+                    <p className="text-xs text-muted-foreground">calls</p>
+                  </div>
+                  <div className="text-right">
+                    <p
+                      className={`text-lg font-semibold flex items-center gap-1 ${
+                        brief.content.deltaVsPrior > 0 ? 'text-success' : 'text-destructive'
+                      }`}
+                    >
+                      {brief.content.deltaVsPrior > 0 ? (
+                        <TrendingUp className="h-4 w-4" />
+                      ) : (
+                        <TrendingDown className="h-4 w-4" />
+                      )}
+                      {brief.content.deltaVsPrior > 0 ? '+' : ''}
+                      {brief.content.deltaVsPrior}
+                    </p>
+                    <p className="text-xs text-muted-foreground">vs avg</p>
+                  </div>
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/supervisor/components/CallVolumeChart.tsx
+++ b/frontend/src/pages/supervisor/components/CallVolumeChart.tsx
@@ -1,0 +1,49 @@
+import { Card } from '@/components/ui/card';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import type { DailyMetric } from '@/lib/mock-data';
+
+export interface CallVolumeChartProps {
+  data: DailyMetric[];
+}
+
+export function CallVolumeChart({ data }: CallVolumeChartProps) {
+  return (
+    <Card className="p-6">
+      <h3 className="text-lg font-semibold mb-6">Call Volume</h3>
+      <ResponsiveContainer width="100%" height={250}>
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+          <XAxis
+            dataKey="date"
+            stroke="hsl(var(--muted-foreground))"
+            fontSize={12}
+            tickFormatter={(date) => new Date(date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+          />
+          <YAxis stroke="hsl(var(--muted-foreground))" fontSize={12} />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: 'hsl(var(--card))',
+              border: '1px solid hsl(var(--border))',
+              borderRadius: '8px',
+            }}
+          />
+          <Line
+            type="monotone"
+            dataKey="callCount"
+            stroke="hsl(var(--accent))"
+            strokeWidth={2}
+            dot={{ fill: 'hsl(var(--accent))' }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </Card>
+  );
+}

--- a/frontend/src/pages/supervisor/components/OverviewStats.tsx
+++ b/frontend/src/pages/supervisor/components/OverviewStats.tsx
@@ -1,0 +1,57 @@
+import { StatCard } from '@/components/StatCard';
+import { TrendingUp, AlertTriangle, Phone } from 'lucide-react';
+
+export type DateRangeOption = '7' | '14' | '30';
+
+export interface OverviewStatsProps {
+  avgSentiment: number;
+  filteredCallCount: number;
+  dateRange: DateRangeOption;
+  negativePercent: number;
+  negativeCallCount: number;
+  openAlerts: number;
+  totalAlerts: number;
+}
+
+export function OverviewStats({
+  avgSentiment,
+  filteredCallCount,
+  dateRange,
+  negativePercent,
+  negativeCallCount,
+  openAlerts,
+  totalAlerts,
+}: OverviewStatsProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+      <StatCard
+        title="Average Sentiment"
+        value={avgSentiment.toFixed(2)}
+        subtitle={`Across ${filteredCallCount} calls`}
+        icon={TrendingUp}
+        variant={avgSentiment > 0.3 ? 'success' : avgSentiment < -0.2 ? 'destructive' : 'default'}
+      />
+      <StatCard
+        title="Call Volume"
+        value={filteredCallCount}
+        subtitle={`Last ${dateRange} days`}
+        icon={Phone}
+        variant="default"
+      />
+      <StatCard
+        title="Negative Calls"
+        value={`${negativePercent.toFixed(1)}%`}
+        subtitle={`${negativeCallCount} calls`}
+        icon={AlertTriangle}
+        variant="warning"
+      />
+      <StatCard
+        title="Open Alerts"
+        value={openAlerts}
+        subtitle={`${totalAlerts} total alerts`}
+        icon={AlertTriangle}
+        variant={openAlerts > 10 ? 'destructive' : 'warning'}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/supervisor/components/RecentAlerts.tsx
+++ b/frontend/src/pages/supervisor/components/RecentAlerts.tsx
@@ -1,0 +1,90 @@
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { SentimentBadge } from '@/components/SentimentBadge';
+import { AlertTriangle, ArrowUpRight, Users, Clock } from 'lucide-react';
+import type { Alert, Call } from '@/lib/mock-data';
+
+export interface RecentAlertsProps {
+  alerts: Alert[];
+  callsById: Record<string, Call>;
+  onViewAll: () => void;
+  onAlertClick: (alert: Alert) => void;
+}
+
+export function RecentAlerts({ alerts, callsById, onViewAll, onAlertClick }: RecentAlertsProps) {
+  return (
+    <Card className="mt-8 p-6">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h3 className="text-lg font-semibold">Recent Alerts</h3>
+          <p className="text-sm text-muted-foreground">High-priority issues requiring attention</p>
+        </div>
+        <Button variant="outline" size="sm" onClick={onViewAll}>
+          View All
+          <ArrowUpRight className="h-4 w-4 ml-2" />
+        </Button>
+      </div>
+      <div className="space-y-4">
+        {alerts.length === 0 ? (
+          <p className="text-muted-foreground text-center py-8">No open alerts</p>
+        ) : (
+          alerts.map((alert) => {
+            const call = callsById[alert.callId];
+            return (
+              <div
+                key={alert.id}
+                className="flex items-center justify-between p-4 rounded-lg border bg-card/50 hover:bg-card transition-colors cursor-pointer"
+                onClick={() => onAlertClick(alert)}
+              >
+                <div className="flex items-start gap-4 flex-1">
+                  <div
+                    className={`p-2 rounded-lg ${
+                      alert.severity === 'high'
+                        ? 'bg-destructive/10'
+                        : alert.severity === 'medium'
+                          ? 'bg-warning/10'
+                          : 'bg-muted'
+                    }`}
+                  >
+                    <AlertTriangle
+                      className={`h-5 w-5 ${
+                        alert.severity === 'high'
+                          ? 'text-destructive'
+                          : alert.severity === 'medium'
+                            ? 'text-warning'
+                            : 'text-muted-foreground'
+                      }`}
+                    />
+                  </div>
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2 mb-1">
+                      <h4 className="font-semibold">{alert.ruleLabel}</h4>
+                      <Badge variant="outline" className="text-xs">
+                        {alert.severity}
+                      </Badge>
+                    </div>
+                    <p className="text-sm text-muted-foreground mb-2">{alert.issue}</p>
+                    {call && (
+                      <div className="flex items-center gap-4 text-xs text-muted-foreground">
+                        <span className="flex items-center gap-1">
+                          <Users className="h-3 w-3" />
+                          {call.agentName}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <Clock className="h-3 w-3" />
+                          {new Date(call.startedAt).toLocaleDateString()}
+                        </span>
+                        <SentimentBadge sentiment={call.sentimentLabel} />
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/pages/supervisor/components/SearchFilters.tsx
+++ b/frontend/src/pages/supervisor/components/SearchFilters.tsx
@@ -1,0 +1,184 @@
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { Slider } from '@/components/ui/slider';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Search, Download, ChevronDown, Loader2 } from 'lucide-react';
+import type { Agent } from '@/lib/mock-data';
+
+export interface SearchFiltersProps {
+  keyword: string;
+  selectedAgentIds: string[];
+  selectedAgentNames: string[];
+  agents: Agent[];
+  sentimentRange: [number, number];
+  dateFrom: string;
+  dateTo: string;
+  loading: boolean;
+  canExport: boolean;
+  onKeywordChange: (value: string) => void;
+  onAgentToggle: (agentId: string) => void;
+  onClearAgents: () => void;
+  onSentimentRangeChange: (value: [number, number]) => void;
+  onDateFromChange: (value: string) => void;
+  onDateToChange: (value: string) => void;
+  onSearch: () => void;
+  onExportCSV: () => void;
+}
+
+export function SearchFilters({
+  keyword,
+  selectedAgentIds,
+  selectedAgentNames,
+  agents,
+  sentimentRange,
+  dateFrom,
+  dateTo,
+  loading,
+  canExport,
+  onKeywordChange,
+  onAgentToggle,
+  onClearAgents,
+  onSentimentRangeChange,
+  onDateFromChange,
+  onDateToChange,
+  onSearch,
+  onExportCSV,
+}: SearchFiltersProps) {
+  return (
+    <Card className="p-6 mb-6">
+      <h2 className="text-lg font-semibold mb-4">Search Calls</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div className="space-y-2">
+          <Label>Keyword</Label>
+          <Input
+            placeholder="Search transcripts, topics..."
+            value={keyword}
+            onChange={(e) => onKeywordChange(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && onSearch()}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>Agents</Label>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                className="w-full justify-between font-normal"
+              >
+                {selectedAgentIds.length === 0 ? (
+                  <span className="text-muted-foreground">Select agents...</span>
+                ) : (
+                  <span className="truncate">
+                    {selectedAgentIds.length} agent{selectedAgentIds.length !== 1 ? 's' : ''} selected
+                  </span>
+                )}
+                <ChevronDown className="h-4 w-4 ml-2 shrink-0 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-64 p-0" align="start">
+              <div className="p-2 border-b">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium">Select Agents</span>
+                  {selectedAgentIds.length > 0 && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-auto p-1 text-xs"
+                      onClick={onClearAgents}
+                    >
+                      Clear all
+                    </Button>
+                  )}
+                </div>
+              </div>
+              <div className="max-h-64 overflow-y-auto p-2">
+                {agents.map((agent) => (
+                  <label
+                    key={agent.id}
+                    className="flex items-center gap-2 p-2 rounded hover:bg-muted cursor-pointer"
+                  >
+                    <Checkbox
+                      checked={selectedAgentIds.includes(agent.id)}
+                      onCheckedChange={() => onAgentToggle(agent.id)}
+                    />
+                    <span className="text-sm">{agent.name}</span>
+                    <Badge variant="secondary" className="ml-auto text-xs">
+                      {agent.team}
+                    </Badge>
+                  </label>
+                ))}
+              </div>
+            </PopoverContent>
+          </Popover>
+          {selectedAgentIds.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-2">
+              {selectedAgentNames.slice(0, 3).map((name) => (
+                <Badge key={name} variant="secondary" className="text-xs">
+                  {name}
+                </Badge>
+              ))}
+              {selectedAgentIds.length > 3 && (
+                <Badge variant="outline" className="text-xs">
+                  +{selectedAgentIds.length - 3} more
+                </Badge>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="space-y-2">
+          <Label>
+            Sentiment Range: [{sentimentRange[0].toFixed(1)}, {sentimentRange[1].toFixed(1)}]
+          </Label>
+          <Slider
+            min={-1}
+            max={1}
+            step={0.1}
+            value={sentimentRange}
+            onValueChange={(value) => onSentimentRangeChange(value as [number, number])}
+            className="py-4"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>From Date</Label>
+          <Input
+            type="date"
+            value={dateFrom}
+            onChange={(e) => onDateFromChange(e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label>To Date</Label>
+          <Input
+            type="date"
+            value={dateTo}
+            onChange={(e) => onDateToChange(e.target.value)}
+          />
+        </div>
+        <div className="flex items-end gap-2">
+          <Button onClick={onSearch} disabled={loading} className="flex-1">
+            {loading ? (
+              <Loader2 className="h-4 w-4 animate-spin mr-2" />
+            ) : (
+              <Search className="h-4 w-4 mr-2" />
+            )}
+            Search
+          </Button>
+          {canExport && (
+            <Button variant="outline" onClick={onExportCSV}>
+              <Download className="h-4 w-4 mr-2" />
+              CSV
+            </Button>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/pages/supervisor/components/SearchResults.tsx
+++ b/frontend/src/pages/supervisor/components/SearchResults.tsx
@@ -1,0 +1,111 @@
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { SentimentBadge } from '@/components/SentimentBadge';
+import { User, Clock } from 'lucide-react';
+import type { Call } from '@/lib/mock-data';
+import type { SearchResult } from '@/lib/mock-service';
+
+export interface SearchResultsProps {
+  results: SearchResult;
+  keyword: string;
+  loading: boolean;
+  onPageChange: (page: number) => void;
+  onSelectCall: (call: Call) => void;
+  getSnippet: (call: Call) => string;
+  highlightKeyword: (text: string) => React.ReactNode;
+  formatDuration: (seconds: number) => string;
+}
+
+export function SearchResults({
+  results,
+  onPageChange,
+  onSelectCall,
+  getSnippet,
+  highlightKeyword,
+  formatDuration,
+}: SearchResultsProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Found {results.total} calls (page {results.page} of {results.totalPages})
+        </p>
+        {results.totalPages > 1 && (
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={results.page <= 1}
+              onClick={() => onPageChange(results.page - 1)}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={results.page >= results.totalPages}
+              onClick={() => onPageChange(results.page + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {results.calls.length === 0 ? (
+        <Card className="p-8 text-center">
+          <p className="text-muted-foreground">No calls match your search criteria.</p>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {results.calls.map((call) => {
+            const snippet = getSnippet(call);
+            return (
+              <Card
+                key={call.id}
+                className="p-4 hover:bg-muted/50 cursor-pointer transition-colors"
+                onClick={() => onSelectCall(call)}
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-3 mb-2">
+                      <SentimentBadge sentiment={call.sentimentLabel} />
+                      <span className="text-sm text-muted-foreground flex items-center gap-1">
+                        <User className="h-3 w-3" />
+                        {call.agentName}
+                      </span>
+                      <span className="text-sm text-muted-foreground flex items-center gap-1">
+                        <Clock className="h-3 w-3" />
+                        {formatDuration(call.durationSec)}
+                      </span>
+                      <span className="text-sm text-muted-foreground">
+                        {new Date(call.startedAt).toLocaleDateString()}
+                      </span>
+                    </div>
+                    <div className="flex flex-wrap gap-1 mb-2">
+                      {call.topics.map((topic) => (
+                        <Badge key={topic} variant="secondary" className="text-xs">
+                          {highlightKeyword(topic.replace(/-/g, ' '))}
+                        </Badge>
+                      ))}
+                    </div>
+                    {snippet && (
+                      <p className="text-sm text-muted-foreground line-clamp-2">
+                        {highlightKeyword(snippet)}
+                      </p>
+                    )}
+                  </div>
+                  <div className="text-right shrink-0">
+                    <p className="text-lg font-semibold">{call.sentimentScore.toFixed(2)}</p>
+                    <p className="text-xs text-muted-foreground">sentiment</p>
+                  </div>
+                </div>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/supervisor/components/SentimentTrendChart.tsx
+++ b/frontend/src/pages/supervisor/components/SentimentTrendChart.tsx
@@ -1,0 +1,60 @@
+import { Card } from '@/components/ui/card';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import type { DailyMetric } from '@/lib/mock-data';
+
+export interface SentimentTrendChartProps {
+  data: DailyMetric[];
+}
+
+export function SentimentTrendChart({ data }: SentimentTrendChartProps) {
+  return (
+    <Card className="p-6">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h3 className="text-lg font-semibold">Sentiment Trend</h3>
+          <p className="text-sm text-muted-foreground">Daily average sentiment scores</p>
+        </div>
+      </div>
+      <ResponsiveContainer width="100%" height={300}>
+        <AreaChart data={data}>
+          <defs>
+            <linearGradient id="sentimentGradient" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="hsl(var(--primary))" stopOpacity={0.3} />
+              <stop offset="95%" stopColor="hsl(var(--primary))" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+          <XAxis
+            dataKey="date"
+            stroke="hsl(var(--muted-foreground))"
+            fontSize={12}
+            tickFormatter={(date) => new Date(date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+          />
+          <YAxis stroke="hsl(var(--muted-foreground))" fontSize={12} domain={[-1, 1]} />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: 'hsl(var(--card))',
+              border: '1px solid hsl(var(--border))',
+              borderRadius: '8px',
+            }}
+          />
+          <Area
+            type="monotone"
+            dataKey="avgSentiment"
+            stroke="hsl(var(--primary))"
+            strokeWidth={2}
+            fill="url(#sentimentGradient)"
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </Card>
+  );
+}

--- a/frontend/src/pages/supervisor/components/TopicDistribution.tsx
+++ b/frontend/src/pages/supervisor/components/TopicDistribution.tsx
@@ -1,0 +1,82 @@
+import { Card } from '@/components/ui/card';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+} from 'recharts';
+
+export interface TopicDatum {
+  name: string;
+  value: number;
+}
+
+export interface SentimentDatum {
+  name: 'Positive' | 'Neutral' | 'Negative';
+  value: number;
+  color: string;
+}
+
+export interface TopicDistributionProps {
+  topTopics: TopicDatum[];
+  sentimentDist: SentimentDatum[];
+}
+
+export function TopicDistribution({ topTopics, sentimentDist }: TopicDistributionProps) {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <Card className="p-6">
+        <h3 className="text-lg font-semibold mb-6">Top Call Topics</h3>
+        <ResponsiveContainer width="100%" height={350}>
+          <BarChart data={topTopics} layout="vertical">
+            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+            <XAxis type="number" stroke="hsl(var(--muted-foreground))" fontSize={12} />
+            <YAxis type="category" dataKey="name" stroke="hsl(var(--muted-foreground))" fontSize={12} width={120} />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: 'hsl(var(--card))',
+                border: '1px solid hsl(var(--border))',
+                borderRadius: '8px',
+              }}
+            />
+            <Bar dataKey="value" fill="hsl(var(--primary))" radius={[0, 8, 8, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </Card>
+
+      <Card className="p-6">
+        <h3 className="text-lg font-semibold mb-6">Sentiment Distribution</h3>
+        <ResponsiveContainer width="100%" height={350}>
+          <PieChart>
+            <Pie
+              data={sentimentDist}
+              cx="50%"
+              cy="50%"
+              labelLine={false}
+              label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+              outerRadius={120}
+              dataKey="value"
+            >
+              {sentimentDist.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={entry.color} />
+              ))}
+            </Pie>
+            <Tooltip
+              contentStyle={{
+                backgroundColor: 'hsl(var(--card))',
+                border: '1px solid hsl(var(--border))',
+                borderRadius: '8px',
+              }}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Submission Summary

This deliverable documents a previously completed refactor in `aws-connect-insight` under the VIBE protocol. The broader PR decomposed four "god component" supervisor pages into orchestrator + presentational subcomponents (+1,513 / −1,023 across 17 files). For Lab 2, I am narrowing the writeup to a single low-risk, isolated target from that PR — the extraction of `AlertTable` out of `Alerts.tsx` — because that is the cleanest place to show one specific moment where I rejected a generic AI suggestion and adjusted it for this project's reality (a codebase mid-migration from mock data to a real API). The verification event concerns how call metadata is looked up inside the alerts table, and produces measurable improvements in typing, separation of concerns, and render-time complexity without changing any user-visible behavior.

---

### 🛡️ VIBE Report

1. **Target Selected:** `AlertTable` (`frontend/src/pages/supervisor/components/AlertTable.tsx`), extracted from the ~323-line monolithic `Alerts.tsx` supervisor page. This was low-risk because it is purely presentational — it owns no state, performs no data fetching, dispatches no toasts, and talks to no store. Its only contract with the rest of the app is a typed `AlertTableProps` interface, and it has exactly one caller (`Alerts.tsx`). All state, mutations, and navigation stayed in the orchestrator, so the extraction could not regress business logic; at worst it could only misrender.
2. **The Verification Event:** While pulling the alerts table body out of `Alerts.tsx`, I had to decide how the extracted component should access `Call` data for each row. The original code did this inside the row loop:
   
   ```tsx
   // before — inside Alerts.tsx render
   {filteredAlerts.map((alert) => {
     const call = mockData.calls.find((c) => c.id === alert.callId);
     ...
     <span className="text-sm">{call?.agentName || 'Unknown'}</span>
   ```

**AI's original suggestion (generic "lift the component" move):** move the same code into the new `AlertTable.tsx` verbatim — keep `mockData.calls.find(c => c.id === alert.callId)` inside the row map and add `import { mockData } from '@/lib/mock-data'` at the top of the new component so it remains "self-contained."

**Why I rejected that here:** it was correct React, but wrong for this project. (1) This repo is in the middle of migrating the supervisor dashboard from `mockData` to a real API (`alertsApi` / `callsApi`), so wiring a brand-new presentational component directly to `mockData` would bake in coupling I was about to have to unpick. (2) `Array.prototype.find` inside the row map is O(rows × calls) per render — a latent footgun the moment the table is paginated against real data. (3) Accepting `Call` directly from `mock-data.ts` would leak a mock-shaped type into the component's public prop surface.

**Final implementation:** the orchestrator builds an indexed lookup once and passes it down as a typed prop. `AlertTable` never imports `mockData` at all.

```tsx
// Alerts.tsx (orchestrator)
const callsById = useMemo(
  () => Object.fromEntries(mockData.calls.map((c) => [c.id, c])),
  []
);
```

```25:36:frontend/src/pages/supervisor/components/AlertTable.tsx
export interface AlertTableProps {
  alerts: SupervisorAlertViewModel[];
  callsById: Record<string, SupervisorCallViewModel>;
  statusFilter: string;
  severityFilter: string;
  selectedIds: string[];
  onStatusFilterChange: (value: string) => void;
  onSeverityFilterChange: (value: string) => void;
  onSelectAll: (checked: boolean) => void;
  onSelectRow: (id: string, checked: boolean) => void;
  onOpenDetail: (alert: SupervisorAlertViewModel) => void;
  onOpenCall: (callId: string) => void;
```

Inside the row I replaced the linear scan with an explicit, null-safe indexed lookup:

```tsx
const call = alert.callId ? callsById[alert.callId] : undefined;
```

The `alert.callId ? … : undefined` guard is itself a project-specific correction: not every alert in this domain has a `callId` — `recurring_topic`, `recurring_keyword`, and `manual` alerts don't — so a direct `callsById[alert.callId]` would have implicitly coerced `undefined` into an index lookup and hidden a real edge case.

**Trust Boundary Established:** The refactor makes the alerts surface more stable than it was yesterday in three concrete ways. First, `AlertTable` now has a narrow, typed public contract (`AlertTableProps`) instead of implicitly depending on whatever the page file happens to import — future changes to mock or API data cannot break the table without a type error at the call site. Second, the O(n·m) per-render `mockData.calls.find` was replaced by a memoized `Record<string, Call>` lookup, so row rendering is O(1) per row regardless of call-set size. Third, the component no longer imports `mockData`, which means the same `AlertTable` will drop straight onto the real API-backed orchestrator (already visible on `main`) with zero internal changes. In VIBE terms: the verification boundary is the `AlertTableProps` interface — anything beyond it is the orchestrator's responsibility, anything inside it is now testable and reviewable in isolation.

**Evidence of Execution:**

- PR #135 is **merged to `main`** (commit `014227f`), which means it passed repo checks at merge time.
- Before / after screenshots of the supervisor dashboard (Overview + Alerts) are attached in the PR description.

<table>
  <tr>
    <td>Before</td>
    <td>After</td>
  </tr>
  <tr>
    <td><img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/38725457-4c13-4821-b22b-081b114e0ddf" /></td>
    <td><img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/ad18383d-74a5-4e12-8032-9b409396c658" /></td>
  </tr>
  <tr>
    <td><img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/bdeba497-8cbf-4700-b468-4eff79580ff6" /></td>
    <td><img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/cf563da0-a006-41b3-af8c-7a795b72e925" /></td>
  </tr>
</table>
