### PR TITLE
Kiitan/alerts

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from api.config import get_settings
-from api.routers import agent, analysis, auth, calls, dashboard, health, teams
+from api.routers import agent, alerts, analysis, auth, calls, dashboard, health, teams
 
 
 @asynccontextmanager
@@ -37,6 +37,7 @@ def create_app() -> FastAPI:
     app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
     app.include_router(analysis.router, prefix="/api/analysis", tags=["analysis"])
     app.include_router(dashboard.router, prefix="/api/dashboard", tags=["dashboard"])
+    app.include_router(alerts.router, prefix="/api/alerts", tags=["alerts"])
     app.include_router(calls.router, prefix="/api/calls", tags=["calls"])
     app.include_router(teams.router, prefix="/api/teams", tags=["teams"])
     app.include_router(agent.router, prefix="/api/agent", tags=["agent"])

--- a/backend/api/routers/alerts.py
+++ b/backend/api/routers/alerts.py
@@ -8,18 +8,27 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, model_validator
 
 from api.dependencies import get_current_user, get_supabase_client
+from api.routers.calls import CallDetailResponse, CallDetailTranscriptTurn
 from database.alerts import (
     DEFAULT_RECURRING_MIN_OCCURRENCES,
     DEFAULT_RECURRING_WINDOW_DAYS,
+    MANUAL_ALERT_TYPE,
+    create_alert,
     create_alert_rule,
+    get_alert_by_id,
     get_alert_rule_by_id,
+    get_open_alert_for_call,
     list_alert_rules,
     list_alerts,
     update_alert,
     update_alert_rule,
 )
+from database.analysis import get_analysis_by_call_id
+from database.calls import get_call_by_id as fetch_call_by_id
 from database.constants import AlertRuleType, AlertSeverity, AlertStatus
 from database.exceptions import DatabaseError, NotFoundError
+from database.users import get_user_by_id
+from services.alerts import get_related_call_ids_for_alert
 
 router = APIRouter()
 
@@ -74,6 +83,18 @@ class AlertRulesListResponse(BaseModel):
     """Alert rule listing response."""
 
     rules: list[AlertRuleResponse]
+
+
+class ManualAlertCreateRequest(BaseModel):
+    """Create payload for supervisor-triggered manual alerts."""
+
+    call_id: str
+
+
+class AlertRelatedCallsResponse(BaseModel):
+    """Alert-related call listing response."""
+
+    calls: list[CallDetailResponse]
 
 
 class AlertRuleCreateRequest(BaseModel):
@@ -194,6 +215,76 @@ def _validated_rule_payload(data: dict[str, Any]) -> dict[str, Any]:
     return validated.model_dump(mode="json")
 
 
+def _normalize_transcript(turns: Any) -> list[dict[str, str]]:
+    """Normalize stored transcript turns to the call detail shape."""
+    if not isinstance(turns, list):
+        return []
+
+    normalized_turns: list[dict[str, str]] = []
+    for turn in turns:
+        if not isinstance(turn, dict):
+            continue
+
+        speaker = str(turn.get("speaker", "")).strip()
+        text = str(turn.get("text", "")).strip()
+        if speaker and text:
+            normalized_turns.append(
+                {
+                    "speaker": speaker,
+                    "text": text,
+                    "timestamp": turn.get("timestamp"),
+                }
+            )
+
+    return normalized_turns
+
+
+def _build_call_detail_response(
+    db_client: Any,
+    *,
+    call_id: str,
+    team_id: str,
+    supervisor_id: str,
+) -> CallDetailResponse:
+    """Build the shared supervisor call-detail payload."""
+    call = fetch_call_by_id(db_client, call_id)
+    if call.get("team_id") != team_id:
+        raise NotFoundError(f"Call {call_id} not found")
+
+    agent = get_user_by_id(db_client, call["agent_id"])
+    try:
+        analysis = get_analysis_by_call_id(db_client, call_id)
+    except NotFoundError:
+        analysis = None
+
+    open_alert = get_open_alert_for_call(
+        db_client,
+        call_id=call_id,
+        team_id=team_id,
+        supervisor_id=supervisor_id,
+    )
+    transcript = _normalize_transcript(call.get("transcript"))
+
+    return CallDetailResponse(
+        id=call["id"],
+        agent_id=call["agent_id"],
+        agent_name=" ".join(
+            part for part in [agent.get("first_name"), agent.get("last_name")] if part
+        )
+        or agent.get("email", "Unknown Agent"),
+        started_at=call.get("started_at"),
+        duration_seconds=call.get("duration_seconds"),
+        sentiment_score=analysis.get("sentiment_score") if analysis else None,
+        sentiment_label=analysis.get("sentiment_label") if analysis else None,
+        is_resolved=analysis.get("is_resolved") if analysis else None,
+        topics=analysis.get("topics", []) if analysis else [],
+        summary=analysis.get("summary") if analysis else None,
+        transcript=[CallDetailTranscriptTurn(**turn) for turn in transcript],
+        has_open_alert=open_alert is not None,
+        open_alert_id=open_alert.get("id") if open_alert else None,
+    )
+
+
 @router.get("", response_model=AlertsListResponse)
 def get_alerts(
     current_user: Annotated[dict, Depends(get_current_user)],
@@ -261,6 +352,122 @@ def patch_alert(
         ) from exc
 
     return AlertResponse(**updated)
+
+
+@router.post("/manual", response_model=AlertResponse, status_code=status.HTTP_201_CREATED)
+def post_manual_alert(
+    payload: ManualAlertCreateRequest,
+    current_user: Annotated[dict, Depends(get_current_user)],
+    client: Annotated[Any, Depends(get_supabase_client)],
+) -> AlertResponse:
+    """Create a manual supervisor alert for a specific call."""
+    db_client = _require_client(client)
+    supervisor_id, team_id = _require_supervisor_context(current_user)
+
+    try:
+        call = fetch_call_by_id(db_client, payload.call_id)
+        if call.get("team_id") != team_id:
+            raise NotFoundError(f"Call {payload.call_id} not found")
+
+        existing_open_alert = get_open_alert_for_call(
+            db_client,
+            call_id=payload.call_id,
+            team_id=team_id,
+            supervisor_id=supervisor_id,
+        )
+        if existing_open_alert:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="This call already has an open alert",
+            )
+
+        agent = get_user_by_id(db_client, call["agent_id"])
+        agent_name = " ".join(
+            part for part in [agent.get("first_name"), agent.get("last_name")] if part
+        ) or agent.get("email", "Unknown Agent")
+        description = (
+            f"Supervisor manually flagged {agent_name}'s call from "
+            f"{call.get('started_at') or 'an unknown time'} for review."
+        )
+        created = create_alert(
+            db_client,
+            rule_id=None,
+            call_id=payload.call_id,
+            supervisor_id=supervisor_id,
+            team_id=team_id,
+            alert_type=MANUAL_ALERT_TYPE,
+            severity=AlertSeverity.MEDIUM.value,
+            title="Manual review requested",
+            description=description,
+        )
+    except HTTPException:
+        raise
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except DatabaseError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create manual alert",
+        ) from exc
+
+    return AlertResponse(**created)
+
+
+@router.get("/{alert_id}/calls", response_model=AlertRelatedCallsResponse)
+def get_alert_calls(
+    alert_id: str,
+    current_user: Annotated[dict, Depends(get_current_user)],
+    client: Annotated[Any, Depends(get_supabase_client)],
+) -> AlertRelatedCallsResponse:
+    """Return the calls related to an alert."""
+    db_client = _require_client(client)
+    supervisor_id, team_id = _require_supervisor_context(current_user)
+
+    try:
+        alert = get_alert_by_id(
+            db_client,
+            alert_id=alert_id,
+            team_id=team_id,
+            supervisor_id=supervisor_id,
+        )
+        rule = None
+        if alert.get("rule_id"):
+            rule = get_alert_rule_by_id(
+                db_client,
+                rule_id=alert["rule_id"],
+                team_id=team_id,
+                supervisor_id=supervisor_id,
+            )
+        related_call_ids = get_related_call_ids_for_alert(
+            db_client,
+            team_id=team_id,
+            alert=alert,
+            rule=rule,
+        )
+        calls = [
+            _build_call_detail_response(
+                db_client,
+                call_id=call_id,
+                team_id=team_id,
+                supervisor_id=supervisor_id,
+            )
+            for call_id in related_call_ids
+        ]
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except DatabaseError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to fetch related alert calls",
+        ) from exc
+
+    return AlertRelatedCallsResponse(calls=calls)
 
 
 @router.get("/rules", response_model=AlertRulesListResponse)

--- a/backend/api/routers/alerts.py
+++ b/backend/api/routers/alerts.py
@@ -1,0 +1,385 @@
+"""Alert management endpoints for supervisors."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field, model_validator
+
+from api.dependencies import get_current_user, get_supabase_client
+from database.alerts import (
+    DEFAULT_RECURRING_MIN_OCCURRENCES,
+    DEFAULT_RECURRING_WINDOW_DAYS,
+    create_alert_rule,
+    get_alert_rule_by_id,
+    list_alert_rules,
+    list_alerts,
+    update_alert,
+    update_alert_rule,
+)
+from database.constants import AlertRuleType, AlertSeverity, AlertStatus
+from database.exceptions import DatabaseError, NotFoundError
+
+router = APIRouter()
+
+
+class AlertRuleResponse(BaseModel):
+    """API contract for alert rules."""
+
+    id: str
+    type: AlertRuleType
+    severity: AlertSeverity
+    is_active: bool
+    team_id: str
+    supervisor_id: str
+    sentiment_below: float | None = None
+    keyword: str | None = None
+    topic: str | None = None
+    min_occurrences: int | None = None
+    window_days: int | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class AlertResponse(BaseModel):
+    """API contract for alert records."""
+
+    id: str
+    rule_id: str | None = None
+    type: str
+    severity: AlertSeverity
+    status: AlertStatus
+    is_read: bool
+    call_id: str | None = None
+    matched_value: str | None = None
+    matched_count: int | None = None
+    window_days: int | None = None
+    title: str
+    description: str
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class AlertsListResponse(BaseModel):
+    """Paginated alert listing response."""
+
+    alerts: list[AlertResponse]
+    total: int
+    page: int
+    per_page: int
+
+
+class AlertRulesListResponse(BaseModel):
+    """Alert rule listing response."""
+
+    rules: list[AlertRuleResponse]
+
+
+class AlertRuleCreateRequest(BaseModel):
+    """Create payload for automated alert rules."""
+
+    type: AlertRuleType
+    severity: AlertSeverity
+    is_active: bool = True
+    sentiment_below: float | None = Field(default=None, le=1.0, ge=-1.0)
+    keyword: str | None = None
+    topic: str | None = None
+    min_occurrences: int | None = Field(default=None, ge=1)
+    window_days: int | None = Field(default=None, ge=1)
+
+    @model_validator(mode="after")
+    def validate_rule_shape(self) -> "AlertRuleCreateRequest":
+        """Ensure only the right criteria fields are used for each rule type."""
+        if self.type == AlertRuleType.SENTIMENT_THRESHOLD:
+            if self.sentiment_below is None:
+                raise ValueError("sentiment_below is required for sentiment_threshold rules")
+            self.keyword = None
+            self.topic = None
+            self.min_occurrences = None
+            self.window_days = None
+            return self
+
+        if self.type == AlertRuleType.KEYWORD_MATCH:
+            if not self.keyword or not self.keyword.strip():
+                raise ValueError("keyword is required for keyword_match rules")
+            self.sentiment_below = None
+            self.topic = None
+            self.min_occurrences = None
+            self.window_days = None
+            return self
+
+        if self.type == AlertRuleType.RECURRING_TOPIC:
+            if not self.topic or not self.topic.strip():
+                raise ValueError("topic is required for recurring_topic rules")
+            self.sentiment_below = None
+            self.keyword = None
+            if self.min_occurrences is None:
+                self.min_occurrences = DEFAULT_RECURRING_MIN_OCCURRENCES
+            if self.window_days is None:
+                self.window_days = DEFAULT_RECURRING_WINDOW_DAYS
+            return self
+
+        if not self.keyword or not self.keyword.strip():
+            raise ValueError("keyword is required for recurring_keyword rules")
+        self.sentiment_below = None
+        self.topic = None
+        if self.min_occurrences is None:
+            self.min_occurrences = DEFAULT_RECURRING_MIN_OCCURRENCES
+        if self.window_days is None:
+            self.window_days = DEFAULT_RECURRING_WINDOW_DAYS
+        return self
+
+
+class AlertRulePatchRequest(BaseModel):
+    """Patch payload for automated alert rules."""
+
+    type: AlertRuleType | None = None
+    severity: AlertSeverity | None = None
+    is_active: bool | None = None
+    sentiment_below: float | None = Field(default=None, le=1.0, ge=-1.0)
+    keyword: str | None = None
+    topic: str | None = None
+    min_occurrences: int | None = Field(default=None, ge=1)
+    window_days: int | None = Field(default=None, ge=1)
+
+
+class AlertPatchRequest(BaseModel):
+    """Patch payload for alert state changes."""
+
+    status: AlertStatus | None = None
+    is_read: bool | None = None
+
+    @model_validator(mode="after")
+    def ensure_any_field(self) -> "AlertPatchRequest":
+        """Require at least one mutable field."""
+        if self.status is None and self.is_read is None:
+            raise ValueError("At least one field must be provided")
+        return self
+
+
+def _require_client(client: Any) -> Any:
+    """Ensure the database client is available."""
+    if client is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Database service unavailable",
+        )
+    return client
+
+
+def _require_supervisor_context(current_user: dict) -> tuple[str, str]:
+    """Return supervisor and team IDs for a valid supervisor user."""
+    role = current_user.get("role")
+    if role != "supervisor":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This endpoint is only accessible to supervisors",
+        )
+
+    team_id = current_user.get("team_id")
+    if not team_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User is not assigned to a team",
+        )
+
+    supervisor_id = current_user.get("id")
+    return supervisor_id, team_id
+
+
+def _validated_rule_payload(data: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a full rule payload through the create validator."""
+    validated = AlertRuleCreateRequest.model_validate(data)
+    return validated.model_dump(mode="json")
+
+
+@router.get("", response_model=AlertsListResponse)
+def get_alerts(
+    current_user: Annotated[dict, Depends(get_current_user)],
+    client: Annotated[Any, Depends(get_supabase_client)],
+    status_filter: Annotated[AlertStatus | None, Query(alias="status")] = None,
+    severity: AlertSeverity | None = None,
+    alert_type: Annotated[str | None, Query(alias="type")] = None,
+    is_read: bool | None = None,
+    page: Annotated[int, Query(ge=1)] = 1,
+    per_page: Annotated[int, Query(ge=1, le=100)] = 20,
+) -> AlertsListResponse:
+    """List alerts for the current supervisor's team."""
+    db_client = _require_client(client)
+    supervisor_id, team_id = _require_supervisor_context(current_user)
+
+    try:
+        result = list_alerts(
+            db_client,
+            team_id=team_id,
+            supervisor_id=supervisor_id,
+            status=status_filter.value if status_filter else None,
+            severity=severity.value if severity else None,
+            alert_type=alert_type,
+            is_read=is_read,
+            page=page,
+            per_page=per_page,
+        )
+    except DatabaseError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to fetch alerts",
+        ) from exc
+
+    return AlertsListResponse(**result)
+
+
+@router.patch("/{alert_id}", response_model=AlertResponse)
+def patch_alert(
+    alert_id: str,
+    payload: AlertPatchRequest,
+    current_user: Annotated[dict, Depends(get_current_user)],
+    client: Annotated[Any, Depends(get_supabase_client)],
+) -> AlertResponse:
+    """Update an alert's status and/or read state."""
+    db_client = _require_client(client)
+    supervisor_id, team_id = _require_supervisor_context(current_user)
+
+    try:
+        updated = update_alert(
+            db_client,
+            alert_id=alert_id,
+            team_id=team_id,
+            supervisor_id=supervisor_id,
+            fields=payload.model_dump(exclude_none=True),
+        )
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except DatabaseError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update alert",
+        ) from exc
+
+    return AlertResponse(**updated)
+
+
+@router.get("/rules", response_model=AlertRulesListResponse)
+def get_rules(
+    current_user: Annotated[dict, Depends(get_current_user)],
+    client: Annotated[Any, Depends(get_supabase_client)],
+    is_active: bool | None = None,
+) -> AlertRulesListResponse:
+    """List alert rules for the current supervisor's team."""
+    db_client = _require_client(client)
+    supervisor_id, team_id = _require_supervisor_context(current_user)
+
+    try:
+        rules = list_alert_rules(
+            db_client,
+            team_id=team_id,
+            supervisor_id=supervisor_id,
+            is_active=is_active,
+        )
+    except DatabaseError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to fetch alert rules",
+        ) from exc
+
+    return AlertRulesListResponse(rules=[AlertRuleResponse(**rule) for rule in rules])
+
+
+@router.post("/rules", response_model=AlertRuleResponse, status_code=status.HTTP_201_CREATED)
+def post_rule(
+    payload: AlertRuleCreateRequest,
+    current_user: Annotated[dict, Depends(get_current_user)],
+    client: Annotated[Any, Depends(get_supabase_client)],
+) -> AlertRuleResponse:
+    """Create a new automated alert rule."""
+    db_client = _require_client(client)
+    supervisor_id, team_id = _require_supervisor_context(current_user)
+
+    try:
+        created = create_alert_rule(
+            db_client,
+            supervisor_id=supervisor_id,
+            team_id=team_id,
+            rule_type=payload.type.value,
+            severity=payload.severity.value,
+            is_active=payload.is_active,
+            sentiment_below=payload.sentiment_below,
+            keyword=payload.keyword,
+            topic=payload.topic,
+            min_occurrences=payload.min_occurrences,
+            window_days=payload.window_days,
+        )
+    except DatabaseError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create alert rule",
+        ) from exc
+
+    return AlertRuleResponse(**created)
+
+
+@router.patch("/rules/{rule_id}", response_model=AlertRuleResponse)
+def patch_rule(
+    rule_id: str,
+    payload: AlertRulePatchRequest,
+    current_user: Annotated[dict, Depends(get_current_user)],
+    client: Annotated[Any, Depends(get_supabase_client)],
+) -> AlertRuleResponse:
+    """Update an existing automated alert rule."""
+    db_client = _require_client(client)
+    supervisor_id, team_id = _require_supervisor_context(current_user)
+
+    patch_data = payload.model_dump(exclude_unset=True)
+    if not patch_data:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="At least one field must be provided",
+        )
+
+    try:
+        current_rule = get_alert_rule_by_id(
+            db_client,
+            rule_id=rule_id,
+            team_id=team_id,
+            supervisor_id=supervisor_id,
+        )
+        merged = {
+            "type": current_rule.get("type"),
+            "severity": current_rule.get("severity"),
+            "is_active": current_rule.get("is_active", True),
+            "sentiment_below": current_rule.get("sentiment_below"),
+            "keyword": current_rule.get("keyword"),
+            "topic": current_rule.get("topic"),
+            "min_occurrences": current_rule.get("min_occurrences"),
+            "window_days": current_rule.get("window_days"),
+            **patch_data,
+        }
+        normalized = _validated_rule_payload(merged)
+        updated = update_alert_rule(
+            db_client,
+            rule_id=rule_id,
+            team_id=team_id,
+            supervisor_id=supervisor_id,
+            fields=normalized,
+        )
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    except DatabaseError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update alert rule",
+        ) from exc
+
+    return AlertRuleResponse(**updated)

--- a/backend/api/routers/calls.py
+++ b/backend/api/routers/calls.py
@@ -10,11 +10,18 @@ from pydantic import BaseModel
 
 from api.config import Settings, get_settings
 from api.dependencies import get_current_user, get_supabase_client
-from database.analysis import add_keywords_to_analysis, add_topics_to_analysis, create_analysis
+from database.analysis import (
+    add_keywords_to_analysis,
+    add_topics_to_analysis,
+    create_analysis,
+    get_analysis_by_call_id,
+)
 from database.calls import create_call
+from database.calls import get_call_by_id as fetch_call_by_id
 from database.exceptions import DatabaseError, NotFoundError
 from database.sample_transcripts import get_random_sample_transcript
 from database.teams import get_team_by_id
+from database.users import get_user_by_id
 from services.alerts import evaluate_alert_rules_for_call
 from services.transcript_analysis import (
     DEFAULT_ANALYSIS_MODEL,
@@ -50,6 +57,30 @@ class SimulateCallResponse(BaseModel):
     is_resolved: bool
     topics: list[str]
     keywords: dict[str, bool]
+
+
+class CallDetailTranscriptTurn(BaseModel):
+    """A transcript turn returned for supervisor call detail views."""
+
+    speaker: str
+    text: str
+    timestamp: str | None = None
+
+
+class CallDetailResponse(BaseModel):
+    """Detailed call payload used by the supervisor alerts workflow."""
+
+    id: str
+    agent_id: str
+    agent_name: str
+    started_at: str | None = None
+    duration_seconds: int | None = None
+    sentiment_score: float | None = None
+    sentiment_label: str | None = None
+    is_resolved: bool | None = None
+    topics: list[str]
+    summary: str | None = None
+    transcript: list[CallDetailTranscriptTurn]
 
 
 # =============================================================================
@@ -99,6 +130,57 @@ def _normalize_transcript(turns: Any) -> list[dict[str, str]]:
 # =============================================================================
 # Endpoints
 # =============================================================================
+
+
+@router.get("/{call_id}", response_model=CallDetailResponse)
+def get_call_detail(
+    call_id: str,
+    current_user: Annotated[dict, Depends(get_current_user)],
+    client: Annotated[Any, Depends(get_supabase_client)],
+) -> CallDetailResponse:
+    """Return a single call with enough detail for supervisor alert investigation."""
+    db_client = _require_client(client)
+    team_id = _get_user_team_id(current_user)
+
+    try:
+        call = fetch_call_by_id(db_client, call_id)
+        if call.get("team_id") != team_id:
+            raise NotFoundError(f"Call {call_id} not found")
+
+        agent = get_user_by_id(db_client, call["agent_id"])
+        try:
+            analysis = get_analysis_by_call_id(db_client, call_id)
+        except NotFoundError:
+            analysis = None
+
+        transcript = _normalize_transcript(call.get("transcript"))
+
+        return CallDetailResponse(
+            id=call["id"],
+            agent_id=call["agent_id"],
+            agent_name=" ".join(
+                part for part in [agent.get("first_name"), agent.get("last_name")] if part
+            )
+            or agent.get("email", "Unknown Agent"),
+            started_at=call.get("started_at"),
+            duration_seconds=call.get("duration_seconds"),
+            sentiment_score=analysis.get("sentiment_score") if analysis else None,
+            sentiment_label=analysis.get("sentiment_label") if analysis else None,
+            is_resolved=analysis.get("is_resolved") if analysis else None,
+            topics=analysis.get("topics", []) if analysis else [],
+            summary=analysis.get("summary") if analysis else None,
+            transcript=[CallDetailTranscriptTurn(**turn) for turn in transcript],
+        )
+    except NotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        ) from exc
+    except DatabaseError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to fetch call",
+        ) from exc
 
 
 @router.post("/simulate", response_model=SimulateCallResponse)
@@ -193,7 +275,7 @@ def simulate_call(
                     topics=analysis_result.topics,
                     keywords=analysis_result.keywords,
                 )
-        except Exception as exc:  # noqa: BLE001 - alerting must not block call simulation
+        except Exception:  # noqa: BLE001 - alerting must not block call simulation
             logger.exception(
                 "Alert evaluation failed for simulated call %s",
                 call["id"],

--- a/backend/api/routers/calls.py
+++ b/backend/api/routers/calls.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from api.config import Settings, get_settings
 from api.dependencies import get_current_user, get_supabase_client
+from database.alerts import get_open_alert_for_call
 from database.analysis import (
     add_keywords_to_analysis,
     add_topics_to_analysis,
@@ -81,6 +82,8 @@ class CallDetailResponse(BaseModel):
     topics: list[str]
     summary: str | None = None
     transcript: list[CallDetailTranscriptTurn]
+    has_open_alert: bool = False
+    open_alert_id: str | None = None
 
 
 # =============================================================================
@@ -127,6 +130,19 @@ def _normalize_transcript(turns: Any) -> list[dict[str, str]]:
     return normalized_turns
 
 
+def _get_supervisor_id_for_call_metadata(
+    db_client: Any,
+    current_user: dict,
+    team_id: str,
+) -> str | None:
+    """Resolve the supervisor whose alert state should decorate call detail payloads."""
+    if current_user.get("role") == "supervisor":
+        return current_user.get("id")
+
+    team = get_team_by_id(db_client, team_id)
+    return team.get("supervisor_id")
+
+
 # =============================================================================
 # Endpoints
 # =============================================================================
@@ -148,10 +164,20 @@ def get_call_detail(
             raise NotFoundError(f"Call {call_id} not found")
 
         agent = get_user_by_id(db_client, call["agent_id"])
+        supervisor_id = _get_supervisor_id_for_call_metadata(db_client, current_user, team_id)
         try:
             analysis = get_analysis_by_call_id(db_client, call_id)
         except NotFoundError:
             analysis = None
+
+        open_alert = None
+        if supervisor_id:
+            open_alert = get_open_alert_for_call(
+                db_client,
+                call_id=call_id,
+                team_id=team_id,
+                supervisor_id=supervisor_id,
+            )
 
         transcript = _normalize_transcript(call.get("transcript"))
 
@@ -170,6 +196,8 @@ def get_call_detail(
             topics=analysis.get("topics", []) if analysis else [],
             summary=analysis.get("summary") if analysis else None,
             transcript=[CallDetailTranscriptTurn(**turn) for turn in transcript],
+            has_open_alert=open_alert is not None,
+            open_alert_id=open_alert.get("id") if open_alert else None,
         )
     except NotFoundError as exc:
         raise HTTPException(

--- a/backend/api/routers/calls.py
+++ b/backend/api/routers/calls.py
@@ -1,5 +1,6 @@
 """Call endpoints for agents and supervisors."""
 
+import logging
 import random
 from datetime import datetime, timedelta
 from typing import Annotated, Any
@@ -13,6 +14,8 @@ from database.analysis import add_keywords_to_analysis, add_topics_to_analysis, 
 from database.calls import create_call
 from database.exceptions import DatabaseError, NotFoundError
 from database.sample_transcripts import get_random_sample_transcript
+from database.teams import get_team_by_id
+from services.alerts import evaluate_alert_rules_for_call
 from services.transcript_analysis import (
     DEFAULT_ANALYSIS_MODEL,
     AnalysisServiceError,
@@ -20,6 +23,7 @@ from services.transcript_analysis import (
 )
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 # =============================================================================
@@ -175,11 +179,31 @@ def simulate_call(
                 list(analysis_result.keywords.keys()),
             )
 
-        # Log for debugging
-        print(
-            "Created simulated call "
-            f"{call['id']} for agent {agent_id} "
-            f"using sample transcript {sample_transcript.get('id')}"
+        try:
+            team = get_team_by_id(db_client, team_id)
+            supervisor_id = team.get("supervisor_id")
+            if supervisor_id:
+                evaluate_alert_rules_for_call(
+                    db_client,
+                    team_id=team_id,
+                    supervisor_id=supervisor_id,
+                    call_id=call["id"],
+                    started_at=call["started_at"],
+                    sentiment_score=analysis_result.sentiment_score,
+                    topics=analysis_result.topics,
+                    keywords=analysis_result.keywords,
+                )
+        except Exception as exc:  # noqa: BLE001 - alerting must not block call simulation
+            logger.exception(
+                "Alert evaluation failed for simulated call %s",
+                call["id"],
+            )
+
+        logger.info(
+            "Created simulated call %s for agent %s using sample transcript %s",
+            call["id"],
+            agent_id,
+            sample_transcript.get("id"),
         )
 
         return SimulateCallResponse(

--- a/backend/database/__init__.py
+++ b/backend/database/__init__.py
@@ -1,5 +1,5 @@
 """Database module."""
 
-from . import analysis, auth, calls, sample_transcripts, teams, users
+from . import alerts, analysis, auth, calls, sample_transcripts, teams, users
 
-__all__ = ["analysis", "auth", "users", "teams", "calls", "sample_transcripts"]
+__all__ = ["alerts", "analysis", "auth", "users", "teams", "calls", "sample_transcripts"]

--- a/backend/database/alerts.py
+++ b/backend/database/alerts.py
@@ -8,7 +8,7 @@ from supabase import Client
 
 from .constants import AlertStatus, Tables
 from .decorators import db_operation
-from .exceptions import DatabaseError, NotFoundError
+from .exceptions import NotFoundError
 
 DEFAULT_RECURRING_MIN_OCCURRENCES = 3
 DEFAULT_RECURRING_WINDOW_DAYS = 7
@@ -144,6 +144,10 @@ def update_alert_rule(
         payload["keyword"] = normalize_match_value(payload["keyword"])
     if "topic" in payload:
         payload["topic"] = normalize_match_value(payload["topic"])
+    if payload.get("min_occurrences") is None:
+        payload["min_occurrences"] = DEFAULT_RECURRING_MIN_OCCURRENCES
+    if payload.get("window_days") is None:
+        payload["window_days"] = DEFAULT_RECURRING_WINDOW_DAYS
 
     result = (
         client.table(Tables.ALERT_CONFIGURATIONS)

--- a/backend/database/alerts.py
+++ b/backend/database/alerts.py
@@ -13,6 +13,7 @@ from .exceptions import NotFoundError
 DEFAULT_RECURRING_MIN_OCCURRENCES = 3
 DEFAULT_RECURRING_WINDOW_DAYS = 7
 MAX_PER_PAGE = 100
+MANUAL_ALERT_TYPE = "manual"
 
 
 def normalize_match_value(value: str | None) -> str | None:
@@ -44,6 +45,28 @@ def normalize_alert_record(alert: dict[str, Any]) -> dict[str, Any]:
     normalized.setdefault("matched_count", None)
     normalized.setdefault("window_days", None)
     return normalized
+
+
+@db_operation
+def get_alert_by_id(
+    client: Client,
+    *,
+    alert_id: str,
+    team_id: str,
+    supervisor_id: str,
+) -> dict[str, Any]:
+    """Return a single alert scoped to the supervisor's team."""
+    result = (
+        client.table(Tables.ALERTS)
+        .select("*")
+        .eq("id", alert_id)
+        .eq("team_id", team_id)
+        .eq("supervisor_id", supervisor_id)
+        .execute()
+    )
+    if not result.data:
+        raise NotFoundError(f"Alert {alert_id} not found")
+    return normalize_alert_record(result.data[0])
 
 
 @db_operation
@@ -236,7 +259,7 @@ def update_alert(
 def create_alert(
     client: Client,
     *,
-    rule_id: str,
+    rule_id: str | None,
     call_id: str | None,
     supervisor_id: str,
     team_id: str,
@@ -269,6 +292,30 @@ def create_alert(
 
     result = client.table(Tables.ALERTS).insert(payload).execute()
     return normalize_alert_record(result.data[0])
+
+
+@db_operation
+def get_open_alert_for_call(
+    client: Client,
+    *,
+    call_id: str,
+    team_id: str,
+    supervisor_id: str,
+) -> dict[str, Any] | None:
+    """Return the most recent open alert for a call within the supervisor scope."""
+    result = (
+        client.table(Tables.ALERTS)
+        .select("*")
+        .eq("call_id", call_id)
+        .eq("team_id", team_id)
+        .eq("supervisor_id", supervisor_id)
+        .eq("status", AlertStatus.OPEN.value)
+        .order("created_at", desc=True)
+        .limit(1)
+        .execute()
+    )
+    row = (result.data or [None])[0]
+    return normalize_alert_record(row) if row else None
 
 
 @db_operation
@@ -354,6 +401,7 @@ def get_recent_call_ids(
         .select("id")
         .eq("team_id", team_id)
         .gte("started_at", started_at_from)
+        .order("started_at", desc=True)
     )
     if started_at_to is not None:
         query = query.lte("started_at", started_at_to)

--- a/backend/database/alerts.py
+++ b/backend/database/alerts.py
@@ -1,0 +1,358 @@
+"""Alert rules and alert record helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from supabase import Client
+
+from .constants import AlertStatus, Tables
+from .decorators import db_operation
+from .exceptions import DatabaseError, NotFoundError
+
+DEFAULT_RECURRING_MIN_OCCURRENCES = 3
+DEFAULT_RECURRING_WINDOW_DAYS = 7
+MAX_PER_PAGE = 100
+
+
+def normalize_match_value(value: str | None) -> str | None:
+    """Normalize topic/keyword values for storage and comparisons."""
+    if value is None:
+        return None
+
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def normalize_rule_record(rule: dict[str, Any]) -> dict[str, Any]:
+    """Normalize rule records to the current API shape."""
+    normalized = dict(rule)
+    if normalized.get("severity") is None:
+        normalized["severity"] = "medium"
+    if normalized.get("min_occurrences") is None:
+        normalized["min_occurrences"] = DEFAULT_RECURRING_MIN_OCCURRENCES
+    if normalized.get("window_days") is None:
+        normalized["window_days"] = DEFAULT_RECURRING_WINDOW_DAYS
+    return normalized
+
+
+def normalize_alert_record(alert: dict[str, Any]) -> dict[str, Any]:
+    """Normalize alert records to the current API shape."""
+    normalized = dict(alert)
+    normalized.setdefault("rule_id", None)
+    normalized.setdefault("matched_value", None)
+    normalized.setdefault("matched_count", None)
+    normalized.setdefault("window_days", None)
+    return normalized
+
+
+@db_operation
+def list_alert_rules(
+    client: Client,
+    *,
+    team_id: str,
+    supervisor_id: str | None = None,
+    is_active: bool | None = None,
+) -> list[dict[str, Any]]:
+    """List alert rules for a team and optional supervisor."""
+    query = client.table(Tables.ALERT_CONFIGURATIONS).select("*").eq("team_id", team_id)
+
+    if supervisor_id is not None:
+        query = query.eq("supervisor_id", supervisor_id)
+    if is_active is not None:
+        query = query.eq("is_active", is_active)
+
+    result = query.order("created_at", desc=True).execute()
+    return [normalize_rule_record(rule) for rule in (result.data or [])]
+
+
+@db_operation
+def get_alert_rule_by_id(
+    client: Client,
+    *,
+    rule_id: str,
+    team_id: str,
+    supervisor_id: str,
+) -> dict[str, Any]:
+    """Return a single alert rule scoped to the supervisor's team."""
+    result = (
+        client.table(Tables.ALERT_CONFIGURATIONS)
+        .select("*")
+        .eq("id", rule_id)
+        .eq("team_id", team_id)
+        .eq("supervisor_id", supervisor_id)
+        .execute()
+    )
+    if not result.data:
+        raise NotFoundError(f"Alert rule {rule_id} not found")
+    return normalize_rule_record(result.data[0])
+
+
+@db_operation
+def create_alert_rule(
+    client: Client,
+    *,
+    supervisor_id: str,
+    team_id: str,
+    rule_type: str,
+    severity: str,
+    is_active: bool = True,
+    sentiment_below: float | None = None,
+    keyword: str | None = None,
+    topic: str | None = None,
+    min_occurrences: int | None = None,
+    window_days: int | None = None,
+) -> dict[str, Any]:
+    """Create an alert rule."""
+    payload: dict[str, Any] = {
+        "supervisor_id": supervisor_id,
+        "team_id": team_id,
+        "type": rule_type,
+        "severity": severity,
+        "is_active": is_active,
+        "sentiment_below": sentiment_below,
+        "keyword": normalize_match_value(keyword),
+        "topic": normalize_match_value(topic),
+        "min_occurrences": min_occurrences,
+        "window_days": window_days,
+    }
+
+    if payload["min_occurrences"] is None:
+        payload["min_occurrences"] = DEFAULT_RECURRING_MIN_OCCURRENCES
+    if payload["window_days"] is None:
+        payload["window_days"] = DEFAULT_RECURRING_WINDOW_DAYS
+
+    result = client.table(Tables.ALERT_CONFIGURATIONS).insert(payload).execute()
+    return normalize_rule_record(result.data[0])
+
+
+@db_operation
+def update_alert_rule(
+    client: Client,
+    *,
+    rule_id: str,
+    team_id: str,
+    supervisor_id: str,
+    fields: dict[str, Any],
+) -> dict[str, Any]:
+    """Update an alert rule."""
+    if not fields:
+        raise ValueError("No fields to update")
+
+    payload = dict(fields)
+    if "keyword" in payload:
+        payload["keyword"] = normalize_match_value(payload["keyword"])
+    if "topic" in payload:
+        payload["topic"] = normalize_match_value(payload["topic"])
+
+    result = (
+        client.table(Tables.ALERT_CONFIGURATIONS)
+        .update(payload)
+        .eq("id", rule_id)
+        .eq("team_id", team_id)
+        .eq("supervisor_id", supervisor_id)
+        .execute()
+    )
+    if not result.data:
+        raise NotFoundError(f"Alert rule {rule_id} not found")
+    return normalize_rule_record(result.data[0])
+
+
+@db_operation
+def list_alerts(
+    client: Client,
+    *,
+    team_id: str,
+    supervisor_id: str,
+    status: str | None = None,
+    severity: str | None = None,
+    alert_type: str | None = None,
+    is_read: bool | None = None,
+    page: int = 1,
+    per_page: int = 20,
+) -> dict[str, Any]:
+    """List alerts scoped to the supervisor's team."""
+    page = max(page, 1)
+    per_page = min(max(per_page, 1), MAX_PER_PAGE)
+
+    query = (
+        client.table(Tables.ALERTS)
+        .select("*", count="exact")
+        .eq("team_id", team_id)
+        .eq("supervisor_id", supervisor_id)
+    )
+
+    if status is not None:
+        query = query.eq("status", status)
+    if severity is not None:
+        query = query.eq("severity", severity)
+    if alert_type is not None:
+        query = query.eq("type", alert_type)
+    if is_read is not None:
+        query = query.eq("is_read", is_read)
+
+    offset = (page - 1) * per_page
+    result = query.order("created_at", desc=True).range(offset, offset + per_page - 1).execute()
+
+    return {
+        "alerts": [normalize_alert_record(alert) for alert in (result.data or [])],
+        "total": result.count or 0,
+        "page": page,
+        "per_page": per_page,
+    }
+
+
+@db_operation
+def update_alert(
+    client: Client,
+    *,
+    alert_id: str,
+    team_id: str,
+    supervisor_id: str,
+    fields: dict[str, Any],
+) -> dict[str, Any]:
+    """Update an alert's read state and/or status."""
+    if not fields:
+        raise ValueError("No fields to update")
+
+    result = (
+        client.table(Tables.ALERTS)
+        .update(fields)
+        .eq("id", alert_id)
+        .eq("team_id", team_id)
+        .eq("supervisor_id", supervisor_id)
+        .execute()
+    )
+    if not result.data:
+        raise NotFoundError(f"Alert {alert_id} not found")
+    return normalize_alert_record(result.data[0])
+
+
+@db_operation
+def create_alert(
+    client: Client,
+    *,
+    rule_id: str,
+    call_id: str | None,
+    supervisor_id: str,
+    team_id: str,
+    alert_type: str,
+    severity: str,
+    title: str,
+    description: str,
+    matched_value: str | None = None,
+    matched_count: int | None = None,
+    window_days: int | None = None,
+    is_read: bool = False,
+    status: str = AlertStatus.OPEN.value,
+) -> dict[str, Any]:
+    """Create an alert record."""
+    payload = {
+        "rule_id": rule_id,
+        "call_id": call_id,
+        "supervisor_id": supervisor_id,
+        "team_id": team_id,
+        "type": alert_type,
+        "severity": severity,
+        "status": status,
+        "title": title,
+        "description": description,
+        "is_read": is_read,
+        "matched_value": normalize_match_value(matched_value),
+        "matched_count": matched_count,
+        "window_days": window_days,
+    }
+
+    result = client.table(Tables.ALERTS).insert(payload).execute()
+    return normalize_alert_record(result.data[0])
+
+
+@db_operation
+def get_alert_for_rule_and_call(
+    client: Client,
+    *,
+    rule_id: str,
+    call_id: str,
+    team_id: str,
+    supervisor_id: str,
+    alert_type: str | None = None,
+) -> dict[str, Any] | None:
+    """Return the alert generated by a call-level rule for the given call."""
+    result = (
+        client.table(Tables.ALERTS)
+        .select("*")
+        .eq("rule_id", rule_id)
+        .eq("call_id", call_id)
+        .eq("team_id", team_id)
+        .eq("supervisor_id", supervisor_id)
+        .execute()
+    )
+    row = (result.data or [None])[0]
+    return normalize_alert_record(row) if row else None
+
+
+@db_operation
+def get_open_recurring_alert(
+    client: Client,
+    *,
+    rule_id: str,
+    matched_value: str,
+    team_id: str,
+    supervisor_id: str,
+) -> dict[str, Any] | None:
+    """Return the currently open recurring alert for a rule and value."""
+    result = (
+        client.table(Tables.ALERTS)
+        .select("*")
+        .eq("rule_id", rule_id)
+        .eq("matched_value", normalize_match_value(matched_value))
+        .eq("team_id", team_id)
+        .eq("supervisor_id", supervisor_id)
+        .eq("status", AlertStatus.OPEN.value)
+        .execute()
+    )
+    row = (result.data or [None])[0]
+    return normalize_alert_record(row) if row else None
+
+
+@db_operation
+def update_generated_alert(
+    client: Client,
+    *,
+    alert_id: str,
+    fields: dict[str, Any],
+) -> dict[str, Any]:
+    """Update an internally generated alert."""
+    if not fields:
+        raise ValueError("No fields to update")
+
+    payload = dict(fields)
+    if "matched_value" in payload:
+        payload["matched_value"] = normalize_match_value(payload["matched_value"])
+
+    result = client.table(Tables.ALERTS).update(payload).eq("id", alert_id).execute()
+    if not result.data:
+        raise NotFoundError(f"Alert {alert_id} not found")
+    return normalize_alert_record(result.data[0])
+
+
+@db_operation
+def get_recent_call_ids(
+    client: Client,
+    *,
+    team_id: str,
+    started_at_from: str,
+    started_at_to: str | None = None,
+) -> list[str]:
+    """Return call IDs for a team in the given time window."""
+    query = (
+        client.table(Tables.CALLS)
+        .select("id")
+        .eq("team_id", team_id)
+        .gte("started_at", started_at_from)
+    )
+    if started_at_to is not None:
+        query = query.lte("started_at", started_at_to)
+
+    result = query.execute()
+    return [row["id"] for row in (result.data or []) if row.get("id")]

--- a/backend/database/constants.py
+++ b/backend/database/constants.py
@@ -13,6 +13,8 @@ class Tables:
     SAMPLE_TRANSCRIPTS = "sample_transcripts"
     TOPICS = "topics"
     KEYWORDS = "keywords"
+    ALERT_CONFIGURATIONS = "alert_configurations"
+    ALERTS = "alerts"
     USERS = "users"
     TEAMS = "teams"
 
@@ -29,3 +31,27 @@ class SortOrder(Enum):
 
     RECENT = "recent"
     OLDEST = "oldest"
+
+
+class AlertRuleType(str, Enum):
+    """Supported automated alert rule types."""
+
+    SENTIMENT_THRESHOLD = "sentiment_threshold"
+    KEYWORD_MATCH = "keyword_match"
+    RECURRING_TOPIC = "recurring_topic"
+    RECURRING_KEYWORD = "recurring_keyword"
+
+
+class AlertSeverity(str, Enum):
+    """Supported alert severity levels."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class AlertStatus(str, Enum):
+    """Supported alert lifecycle states."""
+
+    OPEN = "open"
+    CLOSED = "closed"

--- a/backend/scripts/alerts_live_curl_checks.sh
+++ b/backend/scripts/alerts_live_curl_checks.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8000}"
+SUPERVISOR_EMAIL="${SUPERVISOR_EMAIL:-}"
+SUPERVISOR_PASSWORD="${SUPERVISOR_PASSWORD:-}"
+AGENT_EMAIL="${AGENT_EMAIL:-}"
+AGENT_PASSWORD="${AGENT_PASSWORD:-}"
+SUPERVISOR_COOKIE_JAR="${SUPERVISOR_COOKIE_JAR:-${TMPDIR:-/tmp}/aws-connect-insight-supervisor-alerts-cookies.txt}"
+AGENT_COOKIE_JAR="${AGENT_COOKIE_JAR:-${TMPDIR:-/tmp}/aws-connect-insight-agent-alerts-cookies.txt}"
+RULE_RESPONSE_FILE="${RULE_RESPONSE_FILE:-${TMPDIR:-/tmp}/aws-connect-insight-alert-rule.json}"
+SIM_RESPONSE_FILE="${SIM_RESPONSE_FILE:-${TMPDIR:-/tmp}/aws-connect-insight-alert-simulate.json}"
+ALERTS_RESPONSE_FILE="${ALERTS_RESPONSE_FILE:-${TMPDIR:-/tmp}/aws-connect-insight-alerts-list.json}"
+ACTION="${1:-all}"
+
+RULE_ID=""
+CALL_ID=""
+
+print_usage() {
+  cat <<EOF
+Usage:
+  bash backend/scripts/alerts_live_curl_checks.sh [action]
+
+Actions:
+  all                 Run the end-to-end live alert flow against a running backend
+  health              GET /health
+  login-supervisor    POST /api/auth/login as supervisor
+  login-agent         POST /api/auth/login as agent
+  me-supervisor       GET /api/auth/me using supervisor cookies
+  me-agent            GET /api/auth/me using agent cookies
+  create-rule         POST /api/alerts/rules for a threshold rule that should trigger on almost any call
+  list-rules          GET /api/alerts/rules
+  simulate            POST /api/calls/simulate as agent
+  list-alerts         GET /api/alerts as supervisor
+  verify              Verify stored rule, simulate, and alert responses
+  help                Show this help
+
+Required environment variables:
+  SUPERVISOR_EMAIL       Existing supervisor email
+  SUPERVISOR_PASSWORD    Password for SUPERVISOR_EMAIL
+  AGENT_EMAIL            Existing agent email on the same team
+  AGENT_PASSWORD         Password for AGENT_EMAIL
+
+Optional environment variables:
+  BASE_URL               Backend address. Default: http://localhost:8000
+  SUPERVISOR_COOKIE_JAR  File used for supervisor auth cookies
+  AGENT_COOKIE_JAR       File used for agent auth cookies
+  RULE_RESPONSE_FILE     File used to store created rule JSON
+  SIM_RESPONSE_FILE      File used to store simulate response JSON
+  ALERTS_RESPONSE_FILE   File used to store alert list JSON
+
+Examples:
+  SUPERVISOR_EMAIL=supervisor@example.com SUPERVISOR_PASSWORD=password123 \\
+  AGENT_EMAIL=agent@example.com AGENT_PASSWORD=password123 \\
+    bash backend/scripts/alerts_live_curl_checks.sh all
+
+  SUPERVISOR_EMAIL=supervisor@example.com SUPERVISOR_PASSWORD=password123 \\
+    bash backend/scripts/alerts_live_curl_checks.sh list-rules
+EOF
+}
+
+section() {
+  printf '\n==> %s\n' "$1"
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    printf 'Missing required command: %s\n' "$cmd" >&2
+    exit 1
+  fi
+}
+
+require_supervisor_env() {
+  if [[ -z "$SUPERVISOR_EMAIL" || -z "$SUPERVISOR_PASSWORD" ]]; then
+    printf 'SUPERVISOR_EMAIL and SUPERVISOR_PASSWORD are required.\n' >&2
+    exit 1
+  fi
+}
+
+require_agent_env() {
+  if [[ -z "$AGENT_EMAIL" || -z "$AGENT_PASSWORD" ]]; then
+    printf 'AGENT_EMAIL and AGENT_PASSWORD are required.\n' >&2
+    exit 1
+  fi
+}
+
+json_request() {
+  local method="$1"
+  local endpoint="$2"
+  local payload="$3"
+  shift 3
+  curl -sS -i -X "$method" "$BASE_URL$endpoint" \
+    -H "Content-Type: application/json" \
+    "$@" \
+    --data "$payload"
+  printf '\n'
+}
+
+health() {
+  section "GET /health"
+  curl -sS -i "$BASE_URL/health"
+  printf '\n'
+}
+
+login_supervisor() {
+  require_supervisor_env
+  section "POST /api/auth/login as supervisor"
+  : > "$SUPERVISOR_COOKIE_JAR"
+  json_request "POST" "/api/auth/login" \
+    "$(printf '{"email":"%s","password":"%s"}' "$SUPERVISOR_EMAIL" "$SUPERVISOR_PASSWORD")" \
+    -c "$SUPERVISOR_COOKIE_JAR"
+}
+
+login_agent() {
+  require_agent_env
+  section "POST /api/auth/login as agent"
+  : > "$AGENT_COOKIE_JAR"
+  json_request "POST" "/api/auth/login" \
+    "$(printf '{"email":"%s","password":"%s"}' "$AGENT_EMAIL" "$AGENT_PASSWORD")" \
+    -c "$AGENT_COOKIE_JAR"
+}
+
+me_supervisor() {
+  section "GET /api/auth/me as supervisor"
+  curl -sS -i "$BASE_URL/api/auth/me" -b "$SUPERVISOR_COOKIE_JAR"
+  printf '\n'
+}
+
+me_agent() {
+  section "GET /api/auth/me as agent"
+  curl -sS -i "$BASE_URL/api/auth/me" -b "$AGENT_COOKIE_JAR"
+  printf '\n'
+}
+
+create_rule() {
+  require_cmd jq
+  section "POST /api/alerts/rules"
+  local body
+  body="$(curl -sS -X POST "$BASE_URL/api/alerts/rules" \
+    -H "Content-Type: application/json" \
+    -b "$SUPERVISOR_COOKIE_JAR" -c "$SUPERVISOR_COOKIE_JAR" \
+    --data '{"type":"sentiment_threshold","severity":"high","sentiment_below":1.0,"is_active":true}')"
+  printf '%s\n' "$body" | tee "$RULE_RESPONSE_FILE"
+  RULE_ID="$(printf '%s' "$body" | jq -r '.id // empty')"
+  printf '\nSaved rule response to %s\n' "$RULE_RESPONSE_FILE"
+}
+
+list_rules() {
+  section "GET /api/alerts/rules"
+  curl -sS "$BASE_URL/api/alerts/rules" -b "$SUPERVISOR_COOKIE_JAR" | tee "$RULE_RESPONSE_FILE"
+  printf '\n'
+}
+
+simulate() {
+  require_cmd jq
+  section "POST /api/calls/simulate as agent"
+  local body
+  body="$(curl -sS -X POST "$BASE_URL/api/calls/simulate" -b "$AGENT_COOKIE_JAR" -c "$AGENT_COOKIE_JAR")"
+  printf '%s\n' "$body" | tee "$SIM_RESPONSE_FILE"
+  CALL_ID="$(printf '%s' "$body" | jq -r '.call_id // empty')"
+  printf '\nSaved simulate response to %s\n' "$SIM_RESPONSE_FILE"
+}
+
+list_alerts() {
+  section "GET /api/alerts as supervisor"
+  curl -sS "$BASE_URL/api/alerts" -b "$SUPERVISOR_COOKIE_JAR" | tee "$ALERTS_RESPONSE_FILE"
+  printf '\n'
+}
+
+verify() {
+  require_cmd jq
+
+  if [[ ! -f "$RULE_RESPONSE_FILE" ]]; then
+    printf 'RULE_RESPONSE_FILE does not exist: %s\n' "$RULE_RESPONSE_FILE" >&2
+    exit 1
+  fi
+  if [[ ! -f "$SIM_RESPONSE_FILE" ]]; then
+    printf 'SIM_RESPONSE_FILE does not exist: %s\n' "$SIM_RESPONSE_FILE" >&2
+    exit 1
+  fi
+  if [[ ! -f "$ALERTS_RESPONSE_FILE" ]]; then
+    printf 'ALERTS_RESPONSE_FILE does not exist: %s\n' "$ALERTS_RESPONSE_FILE" >&2
+    exit 1
+  fi
+
+  section "Verify created rule"
+  jq -e '
+    (.id | type == "string" and length > 0) and
+    (.type == "sentiment_threshold") and
+    (.severity == "high") and
+    (.sentiment_below == 1)
+  ' "$RULE_RESPONSE_FILE" >/dev/null
+  RULE_ID="$(jq -r '.id' "$RULE_RESPONSE_FILE")"
+  printf 'rule_id=%s\n' "$RULE_ID"
+
+  section "Verify simulate response"
+  jq -e '
+    (.call_id | type == "string" and length > 0) and
+    (.transcript | type == "array" and length > 0) and
+    (.summary | type == "string" and length > 0) and
+    (.sentiment_score | type == "number")
+  ' "$SIM_RESPONSE_FILE" >/dev/null
+  CALL_ID="$(jq -r '.call_id' "$SIM_RESPONSE_FILE")"
+  printf 'call_id=%s\n' "$CALL_ID"
+  printf 'sentiment_score=%s\n' "$(jq -r '.sentiment_score' "$SIM_RESPONSE_FILE")"
+
+  section "Verify alert list contains triggered alert"
+  jq -e --arg rule_id "$RULE_ID" --arg call_id "$CALL_ID" '
+    (.alerts | type == "array") and
+    (
+      .alerts
+      | map(
+          select(
+            .call_id == $call_id and
+            .rule_id == $rule_id
+          )
+        )
+      | length >= 1
+    )
+  ' "$ALERTS_RESPONSE_FILE" >/dev/null
+
+  jq -r --arg rule_id "$RULE_ID" --arg call_id "$CALL_ID" '
+    .alerts[]
+    | select(
+        .call_id == $call_id and
+        .rule_id == $rule_id
+      )
+    | "alert_id=\(.id)\nalert_type=\(.type)\nalert_status=\(.status)\nalert_title=\(.title)"
+  ' "$ALERTS_RESPONSE_FILE"
+}
+
+all() {
+  require_cmd curl
+  require_cmd jq
+  require_supervisor_env
+  require_agent_env
+
+  printf 'BASE_URL=%s\n' "$BASE_URL"
+  printf 'SUPERVISOR_EMAIL=%s\n' "$SUPERVISOR_EMAIL"
+  printf 'AGENT_EMAIL=%s\n' "$AGENT_EMAIL"
+  printf 'SUPERVISOR_COOKIE_JAR=%s\n' "$SUPERVISOR_COOKIE_JAR"
+  printf 'AGENT_COOKIE_JAR=%s\n' "$AGENT_COOKIE_JAR"
+
+  health
+  login_supervisor
+  me_supervisor
+  create_rule
+  login_agent
+  me_agent
+  simulate
+  list_alerts
+  verify
+}
+
+case "$ACTION" in
+  all)
+    all
+    ;;
+  health)
+    health
+    ;;
+  login-supervisor)
+    login_supervisor
+    ;;
+  login-agent)
+    login_agent
+    ;;
+  me-supervisor)
+    me_supervisor
+    ;;
+  me-agent)
+    me_agent
+    ;;
+  create-rule)
+    create_rule
+    ;;
+  list-rules)
+    list_rules
+    ;;
+  simulate)
+    simulate
+    ;;
+  list-alerts)
+    list_alerts
+    ;;
+  verify)
+    verify
+    ;;
+  help|-h|--help)
+    print_usage
+    ;;
+  *)
+    printf 'Unknown action: %s\n\n' "$ACTION" >&2
+    print_usage
+    exit 1
+    ;;
+esac

--- a/backend/services/alerts.py
+++ b/backend/services/alerts.py
@@ -6,8 +6,8 @@ from collections import Counter
 from datetime import datetime, timedelta
 from typing import Any
 
-from database import analysis as analysis_helpers
 from database import alerts as alert_helpers
+from database import analysis as analysis_helpers
 from database.constants import AlertRuleType
 
 

--- a/backend/services/alerts.py
+++ b/backend/services/alerts.py
@@ -55,6 +55,22 @@ def _count_recent_dimension_occurrences(
     return counts
 
 
+def _filter_matching_call_ids(
+    call_ids: list[str],
+    analyses: list[dict[str, Any]],
+    *,
+    key: str,
+    matched_value: str,
+) -> list[str]:
+    """Return matching call IDs while preserving the recent-call ordering."""
+    matched_by_call_id = {
+        analysis["call_id"]
+        for analysis in analyses
+        if matched_value in _normalize_values(analysis.get(key))
+    }
+    return [call_id for call_id in call_ids if call_id in matched_by_call_id]
+
+
 def _upsert_call_level_alert(
     client: Any,
     *,
@@ -291,3 +307,58 @@ def evaluate_alert_rules_for_call(
             )
 
     return triggered_alerts
+
+
+def get_related_call_ids_for_alert(
+    client: Any,
+    *,
+    team_id: str,
+    alert: dict[str, Any],
+    rule: dict[str, Any] | None = None,
+) -> list[str]:
+    """Return the related call IDs for a single-call, manual, or recurring alert."""
+    call_id = alert.get("call_id")
+    if call_id:
+        return [call_id]
+
+    alert_type = alert.get("type")
+    if alert_type not in {
+        AlertRuleType.RECURRING_TOPIC.value,
+        AlertRuleType.RECURRING_KEYWORD.value,
+    }:
+        return []
+
+    matched_value = alert_helpers.normalize_match_value(alert.get("matched_value"))
+    if not matched_value:
+        return []
+
+    window_days = alert.get("window_days") or (rule or {}).get("window_days")
+    if not window_days:
+        return []
+
+    window_end = alert.get("updated_at") or alert.get("created_at")
+    if not window_end:
+        return []
+
+    recent_call_ids = alert_helpers.get_recent_call_ids(
+        client,
+        team_id=team_id,
+        started_at_from=_window_start(window_end, int(window_days)),
+        started_at_to=window_end,
+    )
+    analyses = analysis_helpers.get_analyses_by_call_ids(client, recent_call_ids)
+
+    if alert_type == AlertRuleType.RECURRING_TOPIC.value:
+        return _filter_matching_call_ids(
+            recent_call_ids,
+            analyses,
+            key="topics",
+            matched_value=matched_value,
+        )
+
+    return _filter_matching_call_ids(
+        recent_call_ids,
+        analyses,
+        key="keywords",
+        matched_value=matched_value,
+    )

--- a/backend/services/alerts.py
+++ b/backend/services/alerts.py
@@ -273,7 +273,7 @@ def evaluate_alert_rules_for_call(
                     title="Recurring topic detected",
                     description=(
                         f'Topic "{topic}" appeared in {matched_count} calls within '
-                        f'the last {rule["window_days"]} days.'
+                        f"the last {rule['window_days']} days."
                     ),
                 )
             )
@@ -301,7 +301,7 @@ def evaluate_alert_rules_for_call(
                     title="Recurring keyword detected",
                     description=(
                         f'Keyword "{keyword}" appeared in {matched_count} calls within '
-                        f'the last {rule["window_days"]} days.'
+                        f"the last {rule['window_days']} days."
                     ),
                 )
             )

--- a/backend/services/alerts.py
+++ b/backend/services/alerts.py
@@ -1,0 +1,293 @@
+"""Automated alert rule evaluation."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timedelta
+from typing import Any
+
+from database import analysis as analysis_helpers
+from database import alerts as alert_helpers
+from database.constants import AlertRuleType
+
+
+def _normalize_values(values: list[str] | dict[str, bool] | None) -> set[str]:
+    """Normalize topics/keywords to a lowercase comparable set."""
+    if values is None:
+        return set()
+
+    if isinstance(values, dict):
+        raw_values = values.keys()
+    else:
+        raw_values = values
+
+    normalized: set[str] = set()
+    for value in raw_values:
+        normalized_value = alert_helpers.normalize_match_value(str(value))
+        if normalized_value:
+            normalized.add(normalized_value)
+    return normalized
+
+
+def _parse_iso_datetime(value: str) -> datetime:
+    """Parse ISO timestamps that may include a trailing Z."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _window_start(started_at: str, window_days: int) -> str:
+    """Return the inclusive window start ISO timestamp."""
+    event_time = _parse_iso_datetime(started_at)
+    return (event_time - timedelta(days=window_days)).isoformat()
+
+
+def _count_recent_dimension_occurrences(
+    analyses: list[dict[str, Any]],
+    key: str,
+) -> Counter[str]:
+    """Count normalized topic/keyword occurrences across analyses."""
+    counts: Counter[str] = Counter()
+
+    for analysis in analyses:
+        raw_values = analysis.get(key) or []
+        for value in _normalize_values(raw_values):
+            counts[value] += 1
+
+    return counts
+
+
+def _upsert_call_level_alert(
+    client: Any,
+    *,
+    rule: dict[str, Any],
+    call_id: str,
+    supervisor_id: str,
+    team_id: str,
+    title: str,
+    description: str,
+    matched_value: str | None = None,
+) -> dict[str, Any]:
+    """Create or update the single call-level alert for a rule and call."""
+    existing = alert_helpers.get_alert_for_rule_and_call(
+        client,
+        rule_id=rule["id"],
+        call_id=call_id,
+        team_id=team_id,
+        supervisor_id=supervisor_id,
+        alert_type=rule["type"],
+    )
+    payload = {
+        "severity": rule["severity"],
+        "title": title,
+        "description": description,
+        "matched_value": matched_value,
+    }
+
+    if existing:
+        return alert_helpers.update_generated_alert(
+            client,
+            alert_id=existing["id"],
+            fields=payload,
+        )
+
+    return alert_helpers.create_alert(
+        client,
+        rule_id=rule["id"],
+        call_id=call_id,
+        supervisor_id=supervisor_id,
+        team_id=team_id,
+        alert_type=rule["type"],
+        severity=rule["severity"],
+        title=title,
+        description=description,
+        matched_value=matched_value,
+    )
+
+
+def _upsert_recurring_alert(
+    client: Any,
+    *,
+    rule: dict[str, Any],
+    supervisor_id: str,
+    team_id: str,
+    matched_value: str,
+    matched_count: int,
+    title: str,
+    description: str,
+) -> dict[str, Any]:
+    """Create or update the single open recurring alert for a matched value."""
+    existing = alert_helpers.get_open_recurring_alert(
+        client,
+        rule_id=rule["id"],
+        matched_value=matched_value,
+        team_id=team_id,
+        supervisor_id=supervisor_id,
+    )
+    payload = {
+        "severity": rule["severity"],
+        "title": title,
+        "description": description,
+        "matched_value": matched_value,
+        "matched_count": matched_count,
+        "window_days": rule["window_days"],
+    }
+
+    if existing:
+        return alert_helpers.update_generated_alert(
+            client,
+            alert_id=existing["id"],
+            fields=payload,
+        )
+
+    return alert_helpers.create_alert(
+        client,
+        rule_id=rule["id"],
+        call_id=None,
+        supervisor_id=supervisor_id,
+        team_id=team_id,
+        alert_type=rule["type"],
+        severity=rule["severity"],
+        title=title,
+        description=description,
+        matched_value=matched_value,
+        matched_count=matched_count,
+        window_days=rule["window_days"],
+    )
+
+
+def evaluate_alert_rules_for_call(
+    client: Any,
+    *,
+    team_id: str,
+    supervisor_id: str,
+    call_id: str,
+    started_at: str,
+    sentiment_score: float,
+    topics: list[str],
+    keywords: dict[str, bool] | list[str],
+) -> list[dict[str, Any]]:
+    """Evaluate active team rules against a newly analyzed call."""
+    triggered_alerts: list[dict[str, Any]] = []
+    normalized_topics = _normalize_values(topics)
+    normalized_keywords = _normalize_values(keywords)
+    rules = alert_helpers.list_alert_rules(
+        client,
+        team_id=team_id,
+        supervisor_id=supervisor_id,
+        is_active=True,
+    )
+
+    analyses_by_window: dict[int, list[dict[str, Any]]] = {}
+
+    def get_recent_analyses(window_days: int) -> list[dict[str, Any]]:
+        if window_days not in analyses_by_window:
+            call_ids = alert_helpers.get_recent_call_ids(
+                client,
+                team_id=team_id,
+                started_at_from=_window_start(started_at, window_days),
+                started_at_to=started_at,
+            )
+            analyses_by_window[window_days] = analysis_helpers.get_analyses_by_call_ids(
+                client,
+                call_ids,
+            )
+        return analyses_by_window[window_days]
+
+    for rule in rules:
+        rule_type = rule["type"]
+
+        if rule_type == AlertRuleType.SENTIMENT_THRESHOLD.value:
+            threshold = rule.get("sentiment_below")
+            if threshold is None or sentiment_score >= threshold:
+                continue
+
+            triggered_alerts.append(
+                _upsert_call_level_alert(
+                    client,
+                    rule=rule,
+                    call_id=call_id,
+                    supervisor_id=supervisor_id,
+                    team_id=team_id,
+                    title="Negative sentiment threshold breached",
+                    description=(
+                        f"Call sentiment score {sentiment_score:.2f} fell below "
+                        f"the configured threshold of {threshold:.2f}."
+                    ),
+                )
+            )
+            continue
+
+        if rule_type == AlertRuleType.KEYWORD_MATCH.value:
+            keyword = alert_helpers.normalize_match_value(rule.get("keyword"))
+            if not keyword or keyword not in normalized_keywords:
+                continue
+
+            triggered_alerts.append(
+                _upsert_call_level_alert(
+                    client,
+                    rule=rule,
+                    call_id=call_id,
+                    supervisor_id=supervisor_id,
+                    team_id=team_id,
+                    title="Tracked keyword detected",
+                    description=f'Call matched the tracked keyword "{keyword}".',
+                    matched_value=keyword,
+                )
+            )
+            continue
+
+        if rule_type == AlertRuleType.RECURRING_TOPIC.value:
+            topic = alert_helpers.normalize_match_value(rule.get("topic"))
+            if not topic or topic not in normalized_topics:
+                continue
+
+            analyses = get_recent_analyses(rule["window_days"])
+            counts = _count_recent_dimension_occurrences(analyses, "topics")
+            matched_count = counts.get(topic, 0)
+            if matched_count < rule["min_occurrences"]:
+                continue
+
+            triggered_alerts.append(
+                _upsert_recurring_alert(
+                    client,
+                    rule=rule,
+                    supervisor_id=supervisor_id,
+                    team_id=team_id,
+                    matched_value=topic,
+                    matched_count=matched_count,
+                    title="Recurring topic detected",
+                    description=(
+                        f'Topic "{topic}" appeared in {matched_count} calls within '
+                        f'the last {rule["window_days"]} days.'
+                    ),
+                )
+            )
+            continue
+
+        if rule_type == AlertRuleType.RECURRING_KEYWORD.value:
+            keyword = alert_helpers.normalize_match_value(rule.get("keyword"))
+            if not keyword or keyword not in normalized_keywords:
+                continue
+
+            analyses = get_recent_analyses(rule["window_days"])
+            counts = _count_recent_dimension_occurrences(analyses, "keywords")
+            matched_count = counts.get(keyword, 0)
+            if matched_count < rule["min_occurrences"]:
+                continue
+
+            triggered_alerts.append(
+                _upsert_recurring_alert(
+                    client,
+                    rule=rule,
+                    supervisor_id=supervisor_id,
+                    team_id=team_id,
+                    matched_value=keyword,
+                    matched_count=matched_count,
+                    title="Recurring keyword detected",
+                    description=(
+                        f'Keyword "{keyword}" appeared in {matched_count} calls within '
+                        f'the last {rule["window_days"]} days.'
+                    ),
+                )
+            )
+
+    return triggered_alerts

--- a/backend/tests/test_alert_routes.py
+++ b/backend/tests/test_alert_routes.py
@@ -1,0 +1,307 @@
+"""API tests for supervisor alert routes."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api import dependencies
+from api.main import app as _app
+
+
+@pytest.fixture
+def supervisor_user():
+    """Authenticated supervisor user for alert route tests."""
+    return {
+        "id": "sup-123",
+        "email": "supervisor@example.com",
+        "team_id": "team-456",
+        "role": "supervisor",
+    }
+
+
+@pytest.fixture
+def agent_user():
+    """Authenticated agent user for authorization tests."""
+    return {
+        "id": "agent-123",
+        "email": "agent@example.com",
+        "team_id": "team-456",
+        "role": "agent",
+    }
+
+
+@pytest.fixture
+def user_without_team():
+    """Authenticated supervisor without a team assignment."""
+    return {
+        "id": "sup-123",
+        "email": "supervisor@example.com",
+        "team_id": None,
+        "role": "supervisor",
+    }
+
+
+def _build_client(mock_supabase: MagicMock, user: dict | None) -> TestClient:
+    def _override_get_supabase_client():
+        yield mock_supabase
+
+    _app.dependency_overrides[dependencies.get_supabase_client] = _override_get_supabase_client
+
+    if user is not None:
+        _app.dependency_overrides[dependencies.get_current_user] = lambda: user
+    else:
+        _app.dependency_overrides.pop(dependencies.get_current_user, None)
+
+    client = TestClient(_app)
+    if user is not None:
+        client.cookies.set("access_token", "valid-token")
+    return client
+
+
+@pytest.fixture
+def authenticated_supervisor_client(mock_supabase: MagicMock, supervisor_user: dict):
+    client = _build_client(mock_supabase, supervisor_user)
+    yield client
+    client.close()
+    _app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def unauthenticated_client(mock_supabase: MagicMock):
+    client = _build_client(mock_supabase, None)
+    yield client
+    client.close()
+    _app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def authenticated_agent_client(mock_supabase: MagicMock, agent_user: dict):
+    client = _build_client(mock_supabase, agent_user)
+    yield client
+    client.close()
+    _app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client_without_team(mock_supabase: MagicMock, user_without_team: dict):
+    client = _build_client(mock_supabase, user_without_team)
+    yield client
+    client.close()
+    _app.dependency_overrides.clear()
+
+
+def test_get_alerts_returns_paginated_results(
+    authenticated_supervisor_client: TestClient,
+) -> None:
+    """GET /api/alerts should return filtered, paginated alerts."""
+    with patch("api.routers.alerts.list_alerts") as list_alerts_mock:
+        list_alerts_mock.return_value = {
+            "alerts": [
+                {
+                    "id": "alert-1",
+                    "rule_id": "rule-1",
+                    "type": "keyword_match",
+                    "severity": "high",
+                    "status": "open",
+                    "is_read": False,
+                    "call_id": "call-1",
+                    "matched_value": "refund",
+                    "matched_count": None,
+                    "window_days": None,
+                    "title": "Tracked keyword detected",
+                    "description": "Call matched the tracked keyword \"refund\".",
+                    "created_at": "2026-04-02T12:00:00Z",
+                    "updated_at": "2026-04-02T12:00:00Z",
+                }
+            ],
+            "total": 1,
+            "page": 1,
+            "per_page": 20,
+        }
+
+        response = authenticated_supervisor_client.get(
+            "/api/alerts?status=open&severity=high&type=keyword_match&is_read=false"
+        )
+
+        assert response.status_code == 200
+        assert response.json()["total"] == 1
+        list_alerts_mock.assert_called_once()
+        assert list_alerts_mock.call_args.kwargs["team_id"] == "team-456"
+        assert list_alerts_mock.call_args.kwargs["supervisor_id"] == "sup-123"
+        assert list_alerts_mock.call_args.kwargs["status"] == "open"
+
+
+def test_patch_alert_updates_status_or_read_flag(
+    authenticated_supervisor_client: TestClient,
+) -> None:
+    """PATCH /api/alerts/{id} should update an alert in scope."""
+    with patch("api.routers.alerts.update_alert") as update_alert_mock:
+        update_alert_mock.return_value = {
+            "id": "alert-1",
+            "rule_id": "rule-1",
+            "type": "keyword_match",
+            "severity": "medium",
+            "status": "closed",
+            "is_read": True,
+            "call_id": "call-1",
+            "matched_value": "refund",
+            "matched_count": None,
+            "window_days": None,
+            "title": "Tracked keyword detected",
+            "description": "Call matched the tracked keyword \"refund\".",
+        }
+
+        response = authenticated_supervisor_client.patch(
+            "/api/alerts/alert-1",
+            json={"status": "closed", "is_read": True},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "closed"
+        update_alert_mock.assert_called_once()
+
+
+def test_get_rules_returns_active_and_inactive_rules(
+    authenticated_supervisor_client: TestClient,
+) -> None:
+    """GET /api/alerts/rules should return team-scoped rules."""
+    with patch("api.routers.alerts.list_alert_rules") as list_rules_mock:
+        list_rules_mock.return_value = [
+            {
+                "id": "rule-1",
+                "type": "sentiment_threshold",
+                "severity": "high",
+                "is_active": True,
+                "team_id": "team-456",
+                "supervisor_id": "sup-123",
+                "sentiment_below": -0.4,
+                "keyword": None,
+                "topic": None,
+                "min_occurrences": None,
+                "window_days": None,
+            },
+            {
+                "id": "rule-2",
+                "type": "keyword_match",
+                "severity": "medium",
+                "is_active": False,
+                "team_id": "team-456",
+                "supervisor_id": "sup-123",
+                "sentiment_below": None,
+                "keyword": "refund",
+                "topic": None,
+                "min_occurrences": None,
+                "window_days": None,
+            },
+        ]
+
+        response = authenticated_supervisor_client.get("/api/alerts/rules")
+
+        assert response.status_code == 200
+        assert len(response.json()["rules"]) == 2
+        list_rules_mock.assert_called_once()
+
+
+def test_post_rule_creates_keyword_rule(
+    authenticated_supervisor_client: TestClient,
+) -> None:
+    """POST /api/alerts/rules should create a valid rule."""
+    with patch("api.routers.alerts.create_alert_rule") as create_rule_mock:
+        create_rule_mock.return_value = {
+            "id": "rule-1",
+            "type": "keyword_match",
+            "severity": "high",
+            "is_active": True,
+            "team_id": "team-456",
+            "supervisor_id": "sup-123",
+            "sentiment_below": None,
+            "keyword": "refund",
+            "topic": None,
+            "min_occurrences": None,
+            "window_days": None,
+        }
+
+        response = authenticated_supervisor_client.post(
+            "/api/alerts/rules",
+            json={"type": "keyword_match", "severity": "high", "keyword": "refund"},
+        )
+
+        assert response.status_code == 201
+        assert response.json()["keyword"] == "refund"
+        create_rule_mock.assert_called_once()
+
+
+def test_post_rule_validates_required_fields(
+    authenticated_supervisor_client: TestClient,
+) -> None:
+    """POST /api/alerts/rules should reject incomplete type-specific payloads."""
+    response = authenticated_supervisor_client.post(
+        "/api/alerts/rules",
+        json={"type": "keyword_match", "severity": "high"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_patch_rule_merges_and_updates_rule(
+    authenticated_supervisor_client: TestClient,
+) -> None:
+    """PATCH /api/alerts/rules/{id} should validate the merged rule state."""
+    with (
+        patch("api.routers.alerts.get_alert_rule_by_id") as get_rule_mock,
+        patch("api.routers.alerts.update_alert_rule") as update_rule_mock,
+    ):
+        get_rule_mock.return_value = {
+            "id": "rule-1",
+            "type": "recurring_keyword",
+            "severity": "medium",
+            "is_active": True,
+            "team_id": "team-456",
+            "supervisor_id": "sup-123",
+            "sentiment_below": None,
+            "keyword": "refund",
+            "topic": None,
+            "min_occurrences": 3,
+            "window_days": 7,
+        }
+        update_rule_mock.return_value = {
+            **get_rule_mock.return_value,
+            "severity": "high",
+            "min_occurrences": 5,
+        }
+
+        response = authenticated_supervisor_client.patch(
+            "/api/alerts/rules/rule-1",
+            json={"severity": "high", "min_occurrences": 5},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["severity"] == "high"
+        assert update_rule_mock.call_args.kwargs["fields"]["keyword"] == "refund"
+
+
+def test_alert_routes_require_authentication(unauthenticated_client: TestClient) -> None:
+    """Protected alert routes should require authentication."""
+    response = unauthenticated_client.get("/api/alerts")
+
+    assert response.status_code == 401
+    assert "Not authenticated" in response.json()["detail"]
+
+
+def test_alert_routes_require_supervisor_role(
+    authenticated_agent_client: TestClient,
+) -> None:
+    """Alert routes should reject authenticated agents."""
+    response = authenticated_agent_client.get("/api/alerts")
+
+    assert response.status_code == 403
+    assert "only accessible to supervisors" in response.json()["detail"]
+
+
+def test_alert_routes_require_team_assignment(client_without_team: TestClient) -> None:
+    """Alert routes should reject supervisors without a team."""
+    response = client_without_team.get("/api/alerts")
+
+    assert response.status_code == 403
+    assert "not assigned to a team" in response.json()["detail"]

--- a/backend/tests/test_alert_routes.py
+++ b/backend/tests/test_alert_routes.py
@@ -110,7 +110,7 @@ def test_get_alerts_returns_paginated_results(
                     "matched_count": None,
                     "window_days": None,
                     "title": "Tracked keyword detected",
-                    "description": "Call matched the tracked keyword \"refund\".",
+                    "description": 'Call matched the tracked keyword "refund".',
                     "created_at": "2026-04-02T12:00:00Z",
                     "updated_at": "2026-04-02T12:00:00Z",
                 }
@@ -149,7 +149,7 @@ def test_patch_alert_updates_status_or_read_flag(
             "matched_count": None,
             "window_days": None,
             "title": "Tracked keyword detected",
-            "description": "Call matched the tracked keyword \"refund\".",
+            "description": 'Call matched the tracked keyword "refund".',
         }
 
         response = authenticated_supervisor_client.patch(

--- a/backend/tests/test_alert_routes.py
+++ b/backend/tests/test_alert_routes.py
@@ -162,6 +162,140 @@ def test_patch_alert_updates_status_or_read_flag(
         update_alert_mock.assert_called_once()
 
 
+def test_post_manual_alert_creates_alert(
+    authenticated_supervisor_client: TestClient,
+) -> None:
+    """POST /api/alerts/manual should create a manual supervisor alert."""
+    with (
+        patch("api.routers.alerts.fetch_call_by_id") as fetch_call_mock,
+        patch("api.routers.alerts.get_open_alert_for_call") as get_open_alert_mock,
+        patch("api.routers.alerts.get_user_by_id") as get_user_mock,
+        patch("api.routers.alerts.create_alert") as create_alert_mock,
+    ):
+        fetch_call_mock.return_value = {
+            "id": "call-1",
+            "agent_id": "agent-1",
+            "team_id": "team-456",
+            "started_at": "2026-04-02T12:00:00Z",
+        }
+        get_open_alert_mock.return_value = None
+        get_user_mock.return_value = {
+            "id": "agent-1",
+            "first_name": "Ada",
+            "last_name": "Lovelace",
+            "email": "ada@example.com",
+        }
+        create_alert_mock.return_value = {
+            "id": "alert-manual",
+            "rule_id": None,
+            "type": "manual",
+            "severity": "medium",
+            "status": "open",
+            "is_read": False,
+            "call_id": "call-1",
+            "matched_value": None,
+            "matched_count": None,
+            "window_days": None,
+            "title": "Manual review requested",
+            "description": (
+                "Supervisor manually flagged Ada Lovelace's call "
+                "from 2026-04-02T12:00:00Z for review."
+            ),
+        }
+
+        response = authenticated_supervisor_client.post(
+            "/api/alerts/manual",
+            json={"call_id": "call-1"},
+        )
+
+        assert response.status_code == 201
+        assert response.json()["type"] == "manual"
+        create_alert_mock.assert_called_once()
+
+
+def test_post_manual_alert_rejects_duplicate_open_alert(
+    authenticated_supervisor_client: TestClient,
+) -> None:
+    """POST /api/alerts/manual should reject calls that already have an open alert."""
+    with (
+        patch("api.routers.alerts.fetch_call_by_id") as fetch_call_mock,
+        patch("api.routers.alerts.get_open_alert_for_call") as get_open_alert_mock,
+    ):
+        fetch_call_mock.return_value = {
+            "id": "call-1",
+            "agent_id": "agent-1",
+            "team_id": "team-456",
+            "started_at": "2026-04-02T12:00:00Z",
+        }
+        get_open_alert_mock.return_value = {"id": "alert-1"}
+
+        response = authenticated_supervisor_client.post(
+            "/api/alerts/manual",
+            json={"call_id": "call-1"},
+        )
+
+        assert response.status_code == 409
+        assert response.json()["detail"] == "This call already has an open alert"
+
+
+def test_get_alert_calls_returns_related_calls(
+    authenticated_supervisor_client: TestClient,
+) -> None:
+    """GET /api/alerts/{id}/calls should return related call detail."""
+    with (
+        patch("api.routers.alerts.get_alert_by_id") as get_alert_mock,
+        patch("api.routers.alerts.get_alert_rule_by_id") as get_rule_mock,
+        patch("api.routers.alerts.get_related_call_ids_for_alert") as get_related_call_ids_mock,
+        patch("api.routers.alerts._build_call_detail_response") as build_call_mock,
+    ):
+        get_alert_mock.return_value = {
+            "id": "alert-1",
+            "rule_id": "rule-1",
+            "type": "recurring_keyword",
+            "call_id": None,
+        }
+        get_rule_mock.return_value = {"id": "rule-1", "type": "recurring_keyword"}
+        get_related_call_ids_mock.return_value = ["call-1", "call-2"]
+        build_call_mock.side_effect = [
+            {
+                "id": "call-1",
+                "agent_id": "agent-1",
+                "agent_name": "Ada Lovelace",
+                "started_at": "2026-04-02T12:00:00Z",
+                "duration_seconds": 240,
+                "sentiment_score": -0.4,
+                "sentiment_label": "negative",
+                "is_resolved": False,
+                "topics": ["refund"],
+                "summary": "Customer requested a refund.",
+                "transcript": [],
+                "has_open_alert": False,
+                "open_alert_id": None,
+            },
+            {
+                "id": "call-2",
+                "agent_id": "agent-2",
+                "agent_name": "Grace Hopper",
+                "started_at": "2026-04-01T10:00:00Z",
+                "duration_seconds": 180,
+                "sentiment_score": -0.2,
+                "sentiment_label": "negative",
+                "is_resolved": True,
+                "topics": ["refund"],
+                "summary": "Repeat refund complaint.",
+                "transcript": [],
+                "has_open_alert": False,
+                "open_alert_id": None,
+            },
+        ]
+
+        response = authenticated_supervisor_client.get("/api/alerts/alert-1/calls")
+
+        assert response.status_code == 200
+        assert [call["id"] for call in response.json()["calls"]] == ["call-1", "call-2"]
+        get_related_call_ids_mock.assert_called_once()
+
+
 def test_get_rules_returns_active_and_inactive_rules(
     authenticated_supervisor_client: TestClient,
 ) -> None:

--- a/backend/tests/test_alert_service.py
+++ b/backend/tests/test_alert_service.py
@@ -321,3 +321,95 @@ def test_evaluate_alert_rules_requests_only_active_rules(monkeypatch: pytest.Mon
     )
 
     assert list_rules.call_args.kwargs["is_active"] is True
+
+
+def test_get_related_call_ids_for_alert_returns_single_call_for_manual_alert() -> None:
+    """Manual and single-call alerts should resolve directly to their call_id."""
+    result = alert_service.get_related_call_ids_for_alert(
+        MagicMock(),
+        team_id="team-1",
+        alert={
+            "id": "alert-1",
+            "type": "manual",
+            "call_id": "call-1",
+            "created_at": "2026-04-02T12:00:00",
+            "updated_at": "2026-04-02T12:00:00",
+        },
+    )
+
+    assert result == ["call-1"]
+
+
+def test_get_related_call_ids_for_alert_filters_recurring_topic_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recurring topic drill-down should return only calls matching the topic within the window."""
+    monkeypatch.setattr(
+        alert_service.alert_helpers,
+        "get_recent_call_ids",
+        MagicMock(return_value=["call-3", "call-2", "call-1"]),
+    )
+    monkeypatch.setattr(
+        alert_service.analysis_helpers,
+        "get_analyses_by_call_ids",
+        MagicMock(
+            return_value=[
+                {"call_id": "call-1", "topics": ["billing"], "keywords": []},
+                {"call_id": "call-2", "topics": ["refund"], "keywords": []},
+                {"call_id": "call-3", "topics": ["Refund"], "keywords": []},
+            ]
+        ),
+    )
+
+    result = alert_service.get_related_call_ids_for_alert(
+        MagicMock(),
+        team_id="team-1",
+        alert={
+            "id": "alert-1",
+            "type": AlertRuleType.RECURRING_TOPIC.value,
+            "call_id": None,
+            "matched_value": "refund",
+            "window_days": 7,
+            "created_at": "2026-04-02T12:00:00",
+            "updated_at": "2026-04-03T12:00:00",
+        },
+    )
+
+    assert result == ["call-3", "call-2"]
+
+
+def test_get_related_call_ids_for_alert_filters_recurring_keyword_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recurring keyword drill-down should use the keyword dimension."""
+    monkeypatch.setattr(
+        alert_service.alert_helpers,
+        "get_recent_call_ids",
+        MagicMock(return_value=["call-2", "call-1"]),
+    )
+    monkeypatch.setattr(
+        alert_service.analysis_helpers,
+        "get_analyses_by_call_ids",
+        MagicMock(
+            return_value=[
+                {"call_id": "call-1", "topics": [], "keywords": ["chargeback"]},
+                {"call_id": "call-2", "topics": [], "keywords": ["refund", "chargeback"]},
+            ]
+        ),
+    )
+
+    result = alert_service.get_related_call_ids_for_alert(
+        MagicMock(),
+        team_id="team-1",
+        alert={
+            "id": "alert-2",
+            "type": AlertRuleType.RECURRING_KEYWORD.value,
+            "call_id": None,
+            "matched_value": "chargeback",
+            "window_days": 7,
+            "created_at": "2026-04-02T12:00:00",
+            "updated_at": "2026-04-02T12:30:00",
+        },
+    )
+
+    assert result == ["call-2", "call-1"]

--- a/backend/tests/test_alert_service.py
+++ b/backend/tests/test_alert_service.py
@@ -1,0 +1,323 @@
+"""Unit tests for automated alert evaluation."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from database.constants import AlertRuleType
+from services import alerts as alert_service
+
+
+def test_evaluate_alert_rules_triggers_sentiment_rule(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sentiment rules should trigger when the score falls below threshold."""
+    create_alert = MagicMock(return_value={"id": "alert-1"})
+
+    monkeypatch.setattr(
+        alert_service.alert_helpers,
+        "list_alert_rules",
+        MagicMock(
+            return_value=[
+                {
+                    "id": "rule-1",
+                    "type": AlertRuleType.SENTIMENT_THRESHOLD.value,
+                    "severity": "high",
+                    "sentiment_below": -0.3,
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        alert_service.alert_helpers,
+        "get_alert_for_rule_and_call",
+        MagicMock(return_value=None),
+    )
+    monkeypatch.setattr(alert_service.alert_helpers, "create_alert", create_alert)
+
+    result = alert_service.evaluate_alert_rules_for_call(
+        MagicMock(),
+        team_id="team-1",
+        supervisor_id="sup-1",
+        call_id="call-1",
+        started_at="2026-04-02T12:00:00",
+        sentiment_score=-0.45,
+        topics=["Refund"],
+        keywords={"refund": True},
+    )
+
+    assert result == [{"id": "alert-1"}]
+    create_alert.assert_called_once()
+    assert create_alert.call_args.kwargs["alert_type"] == AlertRuleType.SENTIMENT_THRESHOLD.value
+
+
+def test_evaluate_alert_rules_skips_non_matching_keyword_rule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keyword rules should not trigger when the keyword is absent."""
+    create_alert = MagicMock()
+
+    monkeypatch.setattr(
+        alert_service.alert_helpers,
+        "list_alert_rules",
+        MagicMock(
+            return_value=[
+                {
+                    "id": "rule-1",
+                    "type": AlertRuleType.KEYWORD_MATCH.value,
+                    "severity": "medium",
+                    "keyword": "chargeback",
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(alert_service.alert_helpers, "create_alert", create_alert)
+
+    result = alert_service.evaluate_alert_rules_for_call(
+        MagicMock(),
+        team_id="team-1",
+        supervisor_id="sup-1",
+        call_id="call-1",
+        started_at="2026-04-02T12:00:00",
+        sentiment_score=-0.45,
+        topics=["Refund"],
+        keywords={"refund": True},
+    )
+
+    assert result == []
+    create_alert.assert_not_called()
+
+
+def test_evaluate_alert_rules_normalizes_keyword_matches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keyword comparisons should be lowercase-normalized on both sides."""
+    create_alert = MagicMock(return_value={"id": "alert-1"})
+
+    monkeypatch.setattr(
+        alert_service.alert_helpers,
+        "list_alert_rules",
+        MagicMock(
+            return_value=[
+                {
+                    "id": "rule-1",
+                    "type": AlertRuleType.KEYWORD_MATCH.value,
+                    "severity": "medium",
+                    "keyword": "refund",
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        alert_service.alert_helpers,
+        "get_alert_for_rule_and_call",
+        MagicMock(return_value=None),
+    )
+    monkeypatch.setattr(alert_service.alert_helpers, "create_alert", create_alert)
+
+    result = alert_service.evaluate_alert_rules_for_call(
+        MagicMock(),
+        team_id="team-1",
+        supervisor_id="sup-1",
+        call_id="call-1",
+        started_at="2026-04-02T12:00:00",
+        sentiment_score=0.1,
+        topics=["Billing"],
+        keywords={"Refund": True},
+    )
+
+    assert result == [{"id": "alert-1"}]
+    assert create_alert.call_args.kwargs["matched_value"] == "refund"
+
+
+def test_evaluate_alert_rules_triggers_recurring_topic(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Recurring topic rules should trigger once the threshold is met."""
+    create_alert = MagicMock(return_value={"id": "alert-2"})
+    recent_call_ids = MagicMock(return_value=["call-1", "call-2", "call-3"])
+    recent_analyses = MagicMock(
+        return_value=[
+            {"topics": ["refund"], "keywords": ["refund"]},
+            {"topics": ["Refund"], "keywords": []},
+            {"topics": ["billing", "refund"], "keywords": []},
+        ]
+    )
+
+    monkeypatch.setattr(
+        alert_service.alert_helpers,
+        "list_alert_rules",
+        MagicMock(
+            return_value=[
+                {
+                    "id": "rule-topic",
+                    "type": AlertRuleType.RECURRING_TOPIC.value,
+                    "severity": "high",
+                    "topic": "refund",
+                    "min_occurrences": 3,
+                    "window_days": 7,
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(alert_service.alert_helpers, "get_recent_call_ids", recent_call_ids)
+    monkeypatch.setattr(
+        alert_service.analysis_helpers,
+        "get_analyses_by_call_ids",
+        recent_analyses,
+    )
+    monkeypatch.setattr(
+        alert_service.alert_helpers,
+        "get_open_recurring_alert",
+        MagicMock(return_value=None),
+    )
+    monkeypatch.setattr(alert_service.alert_helpers, "create_alert", create_alert)
+
+    result = alert_service.evaluate_alert_rules_for_call(
+        MagicMock(),
+        team_id="team-1",
+        supervisor_id="sup-1",
+        call_id="call-3",
+        started_at="2026-04-02T12:00:00",
+        sentiment_score=0.1,
+        topics=["Refund"],
+        keywords={"refund": True},
+    )
+
+    assert result == [{"id": "alert-2"}]
+    assert create_alert.call_args.kwargs["matched_count"] == 3
+    assert create_alert.call_args.kwargs["matched_value"] == "refund"
+
+
+def test_evaluate_alert_rules_updates_existing_open_recurring_alert(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recurring rules should update the existing open alert instead of duplicating it."""
+    update_alert = MagicMock(return_value={"id": "alert-open"})
+
+    monkeypatch.setattr(
+        alert_service.alert_helpers,
+        "list_alert_rules",
+        MagicMock(
+            return_value=[
+                {
+                    "id": "rule-keyword",
+                    "type": AlertRuleType.RECURRING_KEYWORD.value,
+                    "severity": "medium",
+                    "keyword": "refund",
+                    "min_occurrences": 3,
+                    "window_days": 7,
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        alert_service.alert_helpers,
+        "get_recent_call_ids",
+        MagicMock(return_value=["call-1", "call-2", "call-3"]),
+    )
+    monkeypatch.setattr(
+        alert_service.analysis_helpers,
+        "get_analyses_by_call_ids",
+        MagicMock(
+            return_value=[
+                {"topics": [], "keywords": ["refund"]},
+                {"topics": [], "keywords": ["Refund"]},
+                {"topics": [], "keywords": ["refund"]},
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        alert_service.alert_helpers,
+        "get_open_recurring_alert",
+        MagicMock(return_value={"id": "alert-open"}),
+    )
+    monkeypatch.setattr(alert_service.alert_helpers, "update_generated_alert", update_alert)
+    monkeypatch.setattr(alert_service.alert_helpers, "create_alert", MagicMock())
+
+    result = alert_service.evaluate_alert_rules_for_call(
+        MagicMock(),
+        team_id="team-1",
+        supervisor_id="sup-1",
+        call_id="call-3",
+        started_at="2026-04-02T12:00:00",
+        sentiment_score=0.1,
+        topics=["billing"],
+        keywords={"Refund": True},
+    )
+
+    assert result == [{"id": "alert-open"}]
+    update_alert.assert_called_once()
+
+
+def test_evaluate_alert_rules_retriggers_closed_recurring_alert_as_new(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Closed recurring alerts should retrigger as new alerts when the threshold is met again."""
+    create_alert = MagicMock(return_value={"id": "alert-new"})
+
+    monkeypatch.setattr(
+        alert_service.alert_helpers,
+        "list_alert_rules",
+        MagicMock(
+            return_value=[
+                {
+                    "id": "rule-keyword",
+                    "type": AlertRuleType.RECURRING_KEYWORD.value,
+                    "severity": "medium",
+                    "keyword": "refund",
+                    "min_occurrences": 3,
+                    "window_days": 7,
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        alert_service.alert_helpers,
+        "get_recent_call_ids",
+        MagicMock(return_value=["call-1", "call-2", "call-3"]),
+    )
+    monkeypatch.setattr(
+        alert_service.analysis_helpers,
+        "get_analyses_by_call_ids",
+        MagicMock(
+            return_value=[
+                {"topics": [], "keywords": ["refund"]},
+                {"topics": [], "keywords": ["refund"]},
+                {"topics": [], "keywords": ["refund"]},
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        alert_service.alert_helpers,
+        "get_open_recurring_alert",
+        MagicMock(return_value=None),
+    )
+    monkeypatch.setattr(alert_service.alert_helpers, "create_alert", create_alert)
+
+    result = alert_service.evaluate_alert_rules_for_call(
+        MagicMock(),
+        team_id="team-1",
+        supervisor_id="sup-1",
+        call_id="call-3",
+        started_at="2026-04-02T12:00:00",
+        sentiment_score=0.1,
+        topics=["billing"],
+        keywords={"refund": True},
+    )
+
+    assert result == [{"id": "alert-new"}]
+    create_alert.assert_called_once()
+
+
+def test_evaluate_alert_rules_requests_only_active_rules(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The evaluator should request only active rules from the helper layer."""
+    list_rules = MagicMock(return_value=[])
+    monkeypatch.setattr(alert_service.alert_helpers, "list_alert_rules", list_rules)
+
+    alert_service.evaluate_alert_rules_for_call(
+        MagicMock(),
+        team_id="team-1",
+        supervisor_id="sup-1",
+        call_id="call-1",
+        started_at="2026-04-02T12:00:00",
+        sentiment_score=0.0,
+        topics=[],
+        keywords={},
+    )
+
+    assert list_rules.call_args.kwargs["is_active"] is True

--- a/backend/tests/test_calls_routes.py
+++ b/backend/tests/test_calls_routes.py
@@ -24,6 +24,17 @@ def agent_user():
 
 
 @pytest.fixture
+def supervisor_user():
+    """Authenticated supervisor user for call detail route tests."""
+    return {
+        "id": "supervisor-123",
+        "email": "supervisor@example.com",
+        "team_id": "team-456",
+        "role": "supervisor",
+    }
+
+
+@pytest.fixture
 def authenticated_agent_client(mock_supabase: MagicMock, agent_user: dict):
     """Client with mocked authentication for agent routes."""
 
@@ -32,6 +43,26 @@ def authenticated_agent_client(mock_supabase: MagicMock, agent_user: dict):
 
     def _override_get_current_user():
         return agent_user
+
+    _app.dependency_overrides[dependencies.get_supabase_client] = _override_get_supabase_client
+    _app.dependency_overrides[dependencies.get_current_user] = _override_get_current_user
+
+    with TestClient(_app) as client:
+        client.cookies.set("access_token", "valid-token")
+        yield client
+
+    _app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def authenticated_supervisor_client(mock_supabase: MagicMock, supervisor_user: dict):
+    """Client with mocked authentication for supervisor routes."""
+
+    def _override_get_supabase_client():
+        yield mock_supabase
+
+    def _override_get_current_user():
+        return supervisor_user
 
     _app.dependency_overrides[dependencies.get_supabase_client] = _override_get_supabase_client
     _app.dependency_overrides[dependencies.get_current_user] = _override_get_current_user
@@ -336,3 +367,96 @@ def test_simulate_call_returns_success_when_alert_evaluation_fails(
 
     assert response.status_code == 200
     assert response.json()["call_id"] == "call-123"
+
+
+def test_get_call_detail_returns_call_for_same_team(
+    authenticated_supervisor_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GET /api/calls/{call_id} should return alert-ready call detail for same-team users."""
+    monkeypatch.setattr(
+        calls_router,
+        "fetch_call_by_id",
+        MagicMock(
+            return_value={
+                "id": "call-123",
+                "agent_id": "agent-123",
+                "team_id": "team-456",
+                "started_at": "2026-04-02T12:00:00Z",
+                "duration_seconds": 305,
+                "transcript": [
+                    {"speaker": "Customer", "text": "I need help with a refund."},
+                    {"speaker": "Agent", "text": "I can help with that."},
+                ],
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        calls_router,
+        "get_user_by_id",
+        MagicMock(
+            return_value={
+                "id": "agent-123",
+                "first_name": "Ada",
+                "last_name": "Lovelace",
+                "email": "ada@example.com",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        calls_router,
+        "get_analysis_by_call_id",
+        MagicMock(
+            return_value={
+                "summary": "Customer requested a refund.",
+                "sentiment_score": -0.4,
+                "sentiment_label": "negative",
+                "is_resolved": False,
+                "topics": ["refund"],
+            }
+        ),
+    )
+
+    response = authenticated_supervisor_client.get("/api/calls/call-123")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "id": "call-123",
+        "agent_id": "agent-123",
+        "agent_name": "Ada Lovelace",
+        "started_at": "2026-04-02T12:00:00Z",
+        "duration_seconds": 305,
+        "sentiment_score": -0.4,
+        "sentiment_label": "negative",
+        "is_resolved": False,
+        "topics": ["refund"],
+        "summary": "Customer requested a refund.",
+        "transcript": [
+            {"speaker": "Customer", "text": "I need help with a refund.", "timestamp": None},
+            {"speaker": "Agent", "text": "I can help with that.", "timestamp": None},
+        ],
+    }
+
+
+def test_get_call_detail_returns_404_for_other_team(
+    authenticated_supervisor_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GET /api/calls/{call_id} should not expose calls from another team."""
+    monkeypatch.setattr(
+        calls_router,
+        "fetch_call_by_id",
+        MagicMock(
+            return_value={
+                "id": "call-123",
+                "agent_id": "agent-123",
+                "team_id": "other-team",
+                "transcript": [],
+            }
+        ),
+    )
+
+    response = authenticated_supervisor_client.get("/api/calls/call-123")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Call call-123 not found"}

--- a/backend/tests/test_calls_routes.py
+++ b/backend/tests/test_calls_routes.py
@@ -416,6 +416,11 @@ def test_get_call_detail_returns_call_for_same_team(
             }
         ),
     )
+    monkeypatch.setattr(
+        calls_router,
+        "get_open_alert_for_call",
+        MagicMock(return_value={"id": "alert-1"}),
+    )
 
     response = authenticated_supervisor_client.get("/api/calls/call-123")
 
@@ -431,6 +436,8 @@ def test_get_call_detail_returns_call_for_same_team(
         "is_resolved": False,
         "topics": ["refund"],
         "summary": "Customer requested a refund.",
+        "has_open_alert": True,
+        "open_alert_id": "alert-1",
         "transcript": [
             {"speaker": "Customer", "text": "I need help with a refund.", "timestamp": None},
             {"speaker": "Agent", "text": "I can help with that.", "timestamp": None},

--- a/backend/tests/test_calls_routes.py
+++ b/backend/tests/test_calls_routes.py
@@ -76,10 +76,14 @@ def test_simulate_call_returns_enriched_payload(
         topics=["Refund"],
         keywords={"refund": True, "issue": True},
     )
-    create_call_mock = MagicMock(return_value={"id": "call-123"})
+    create_call_mock = MagicMock(
+        return_value={"id": "call-123", "started_at": "2026-04-02T12:00:00"}
+    )
     create_analysis_mock = MagicMock(return_value={"id": "analysis-123"})
     add_topics_mock = MagicMock()
     add_keywords_mock = MagicMock()
+    get_team_mock = MagicMock(return_value={"id": "team-456", "supervisor_id": "sup-999"})
+    evaluate_alerts_mock = MagicMock()
 
     monkeypatch.setattr(
         calls_router,
@@ -95,6 +99,8 @@ def test_simulate_call_returns_enriched_payload(
     monkeypatch.setattr(calls_router, "create_analysis", create_analysis_mock)
     monkeypatch.setattr(calls_router, "add_topics_to_analysis", add_topics_mock)
     monkeypatch.setattr(calls_router, "add_keywords_to_analysis", add_keywords_mock)
+    monkeypatch.setattr(calls_router, "get_team_by_id", get_team_mock)
+    monkeypatch.setattr(calls_router, "evaluate_alert_rules_for_call", evaluate_alerts_mock)
     monkeypatch.setattr(
         calls_router.random,
         "randint",
@@ -142,6 +148,11 @@ def test_simulate_call_returns_enriched_payload(
     )
     add_topics_mock.assert_called_once_with(ANY, "analysis-123", ["Refund"])
     add_keywords_mock.assert_called_once_with(ANY, "analysis-123", ["refund", "issue"])
+    get_team_mock.assert_called_once_with(ANY, "team-456")
+    evaluate_alerts_mock.assert_called_once()
+    assert evaluate_alerts_mock.call_args.kwargs["team_id"] == "team-456"
+    assert evaluate_alerts_mock.call_args.kwargs["supervisor_id"] == "sup-999"
+    assert evaluate_alerts_mock.call_args.kwargs["call_id"] == "call-123"
 
 
 def test_simulate_call_returns_503_when_no_sample_transcript(
@@ -258,3 +269,70 @@ def test_simulate_call_returns_500_on_database_failure(
 
     assert response.status_code == 500
     assert response.json() == {"detail": "Failed to simulate call"}
+
+
+def test_simulate_call_returns_success_when_alert_evaluation_fails(
+    authenticated_agent_client: TestClient,
+    simulate_settings_override,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST /api/calls/simulate should still succeed if alert generation fails."""
+    sample_transcript = {
+        "id": "sample-row-1",
+        "transcript": [
+            {"speaker": "Customer", "text": "I need help with a refund."},
+            {"speaker": "Agent", "text": "I can help with that today."},
+        ],
+    }
+    analysis_result = TranscriptAnalysisResponse(
+        summary="Customer requested a refund. Agent provided next steps.",
+        sentiment_score=-0.45,
+        sentiment_label="negative",
+        key_moves=["acknowledged concern", "shared next steps"],
+        is_resolved=False,
+        topics=["Refund"],
+        keywords={"refund": True},
+    )
+
+    monkeypatch.setattr(
+        calls_router,
+        "get_random_sample_transcript",
+        MagicMock(return_value=sample_transcript),
+    )
+    monkeypatch.setattr(
+        calls_router,
+        "analyze_transcript_with_openai",
+        MagicMock(return_value=analysis_result),
+    )
+    monkeypatch.setattr(
+        calls_router,
+        "create_call",
+        MagicMock(return_value={"id": "call-123", "started_at": "2026-04-02T12:00:00"}),
+    )
+    monkeypatch.setattr(
+        calls_router,
+        "create_analysis",
+        MagicMock(return_value={"id": "analysis-123"}),
+    )
+    monkeypatch.setattr(calls_router, "add_topics_to_analysis", MagicMock())
+    monkeypatch.setattr(calls_router, "add_keywords_to_analysis", MagicMock())
+    monkeypatch.setattr(
+        calls_router,
+        "get_team_by_id",
+        MagicMock(return_value={"id": "team-456", "supervisor_id": "sup-999"}),
+    )
+    monkeypatch.setattr(
+        calls_router,
+        "evaluate_alert_rules_for_call",
+        MagicMock(side_effect=RuntimeError("alerting boom")),
+    )
+    monkeypatch.setattr(
+        calls_router.random,
+        "randint",
+        MagicMock(side_effect=[2, 3, 15, 180, 99999]),
+    )
+
+    response = authenticated_agent_client.post("/api/calls/simulate")
+
+    assert response.status_code == 200
+    assert response.json()["call_id"] == "call-123"

--- a/backend/tests/test_database_alerts.py
+++ b/backend/tests/test_database_alerts.py
@@ -1,0 +1,143 @@
+"""Unit tests for alert database helpers."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from database import alerts as alert_helpers
+from database.constants import AlertStatus, Tables
+from database.exceptions import NotFoundError
+
+
+def test_normalize_match_value_lowercases_and_trims() -> None:
+    """normalize_match_value should lowercase and trim values."""
+    assert alert_helpers.normalize_match_value(" Refund ") == "refund"
+    assert alert_helpers.normalize_match_value("   ") is None
+    assert alert_helpers.normalize_match_value(None) is None
+
+
+def test_create_alert_rule_normalizes_fields_and_defaults_recurrence() -> None:
+    """create_alert_rule should normalize keyword/topic fields and apply defaults."""
+    client = MagicMock()
+    client.table.return_value.insert.return_value.execute.return_value = SimpleNamespace(
+        data=[{"id": "rule-1"}]
+    )
+
+    alert_helpers.create_alert_rule(
+        client,
+        supervisor_id="sup-1",
+        team_id="team-1",
+        rule_type="recurring_keyword",
+        severity="high",
+        keyword=" Refund ",
+        topic=" Billing ",
+    )
+
+    client.table.assert_called_once_with(Tables.ALERT_CONFIGURATIONS)
+    client.table.return_value.insert.assert_called_once_with(
+        {
+            "supervisor_id": "sup-1",
+            "team_id": "team-1",
+            "type": "recurring_keyword",
+            "severity": "high",
+            "is_active": True,
+            "sentiment_below": None,
+            "keyword": "refund",
+            "topic": "billing",
+            "min_occurrences": alert_helpers.DEFAULT_RECURRING_MIN_OCCURRENCES,
+            "window_days": alert_helpers.DEFAULT_RECURRING_WINDOW_DAYS,
+        }
+    )
+
+
+def test_list_alerts_applies_filters_and_pagination() -> None:
+    """list_alerts should apply team scoping, filters, and pagination."""
+    client = MagicMock()
+    select_query = MagicMock()
+    query = MagicMock()
+    select_query.eq.return_value = query
+    query.eq.return_value = query
+    query.order.return_value = query
+    query.range.return_value.execute.return_value = SimpleNamespace(data=[], count=0)
+    client.table.return_value.select.return_value = select_query
+
+    result = alert_helpers.list_alerts(
+        client,
+        team_id="team-1",
+        supervisor_id="sup-1",
+        status="open",
+        severity="medium",
+        alert_type="keyword_match",
+        is_read=False,
+        page=2,
+        per_page=10,
+    )
+
+    client.table.assert_called_once_with(Tables.ALERTS)
+    select_query.eq.assert_called_once_with("team_id", "team-1")
+    assert query.eq.call_args_list[0].args == ("supervisor_id", "sup-1")
+    assert query.eq.call_args_list[1].args == ("status", "open")
+    assert query.eq.call_args_list[2].args == ("severity", "medium")
+    assert query.eq.call_args_list[3].args == ("type", "keyword_match")
+    assert query.eq.call_args_list[4].args == ("is_read", False)
+    query.range.assert_called_once_with(10, 19)
+    assert result == {"alerts": [], "total": 0, "page": 2, "per_page": 10}
+
+
+def test_update_alert_rule_normalizes_topic_and_keyword() -> None:
+    """update_alert_rule should normalize mutable match values."""
+    client = MagicMock()
+    client.table.return_value.update.return_value.eq.return_value.eq.return_value.eq.return_value.execute.return_value = SimpleNamespace(
+        data=[{"id": "rule-1"}]
+    )
+
+    alert_helpers.update_alert_rule(
+        client,
+        rule_id="rule-1",
+        team_id="team-1",
+        supervisor_id="sup-1",
+        fields={"keyword": " Cancel ", "topic": " Billing "},
+    )
+
+    client.table.assert_called_once_with(Tables.ALERT_CONFIGURATIONS)
+    client.table.return_value.update.assert_called_once_with(
+        {"keyword": "cancel", "topic": "billing"}
+    )
+
+
+def test_get_open_recurring_alert_normalizes_matched_value() -> None:
+    """get_open_recurring_alert should normalize the matched value lookup."""
+    client = MagicMock()
+    query = MagicMock()
+    (
+        client.table.return_value.select.return_value.eq.return_value.eq.return_value.eq.return_value.eq.return_value.eq.return_value.execute.return_value
+    ) = SimpleNamespace(data=[{"id": "alert-1"}])
+
+    result = alert_helpers.get_open_recurring_alert(
+        client,
+        rule_id="rule-1",
+        matched_value=" Refund ",
+        team_id="team-1",
+        supervisor_id="sup-1",
+    )
+
+    assert result["id"] == "alert-1"
+    assert result["rule_id"] is None
+
+
+def test_update_alert_raises_not_found_for_missing_record() -> None:
+    """update_alert should raise NotFoundError when no row matches the scope."""
+    client = MagicMock()
+    client.table.return_value.update.return_value.eq.return_value.eq.return_value.eq.return_value.execute.return_value = SimpleNamespace(
+        data=[]
+    )
+
+    with pytest.raises(NotFoundError, match="Alert alert-404 not found"):
+        alert_helpers.update_alert(
+            client,
+            alert_id="alert-404",
+            team_id="team-1",
+            supervisor_id="sup-1",
+            fields={"status": AlertStatus.CLOSED.value},
+        )

--- a/backend/tests/test_database_alerts.py
+++ b/backend/tests/test_database_alerts.py
@@ -154,6 +154,47 @@ def test_get_open_recurring_alert_normalizes_matched_value() -> None:
     assert result["rule_id"] is None
 
 
+def test_get_alert_by_id_returns_scoped_alert() -> None:
+    """get_alert_by_id should return an in-scope alert."""
+    client = MagicMock()
+    (
+        client.table.return_value.select.return_value.eq.return_value.eq.return_value.eq.return_value.execute.return_value
+    ) = SimpleNamespace(data=[{"id": "alert-1"}])
+
+    result = alert_helpers.get_alert_by_id(
+        client,
+        alert_id="alert-1",
+        team_id="team-1",
+        supervisor_id="sup-1",
+    )
+
+    assert result["id"] == "alert-1"
+
+
+def test_get_open_alert_for_call_returns_latest_open_alert() -> None:
+    """get_open_alert_for_call should find an open call-level alert."""
+    client = MagicMock()
+    (
+        client.table.return_value.select.return_value.eq.return_value.eq.return_value.eq.return_value.eq.return_value.order.return_value.limit.return_value.execute.return_value
+    ) = SimpleNamespace(data=[{"id": "alert-open", "call_id": "call-1"}])
+
+    result = alert_helpers.get_open_alert_for_call(
+        client,
+        call_id="call-1",
+        team_id="team-1",
+        supervisor_id="sup-1",
+    )
+
+    assert result == {
+        "id": "alert-open",
+        "call_id": "call-1",
+        "rule_id": None,
+        "matched_value": None,
+        "matched_count": None,
+        "window_days": None,
+    }
+
+
 def test_update_alert_raises_not_found_for_missing_record() -> None:
     """update_alert should raise NotFoundError when no row matches the scope."""
     client = MagicMock()

--- a/backend/tests/test_database_alerts.py
+++ b/backend/tests/test_database_alerts.py
@@ -88,9 +88,9 @@ def test_list_alerts_applies_filters_and_pagination() -> None:
 def test_update_alert_rule_normalizes_topic_and_keyword() -> None:
     """update_alert_rule should normalize mutable match values."""
     client = MagicMock()
-    client.table.return_value.update.return_value.eq.return_value.eq.return_value.eq.return_value.execute.return_value = SimpleNamespace(
-        data=[{"id": "rule-1"}]
-    )
+    (
+        client.table.return_value.update.return_value.eq.return_value.eq.return_value.eq.return_value.execute.return_value
+    ) = SimpleNamespace(data=[{"id": "rule-1"}])
 
     alert_helpers.update_alert_rule(
         client,
@@ -102,14 +102,42 @@ def test_update_alert_rule_normalizes_topic_and_keyword() -> None:
 
     client.table.assert_called_once_with(Tables.ALERT_CONFIGURATIONS)
     client.table.return_value.update.assert_called_once_with(
-        {"keyword": "cancel", "topic": "billing"}
+        {
+            "keyword": "cancel",
+            "topic": "billing",
+            "min_occurrences": alert_helpers.DEFAULT_RECURRING_MIN_OCCURRENCES,
+            "window_days": alert_helpers.DEFAULT_RECURRING_WINDOW_DAYS,
+        }
+    )
+
+
+def test_update_alert_rule_applies_defaults_when_null_recurrence_fields_are_provided() -> None:
+    """update_alert_rule should replace null recurrence fields with database-safe defaults."""
+    client = MagicMock()
+    (
+        client.table.return_value.update.return_value.eq.return_value.eq.return_value.eq.return_value.execute.return_value
+    ) = SimpleNamespace(data=[{"id": "rule-1"}])
+
+    alert_helpers.update_alert_rule(
+        client,
+        rule_id="rule-1",
+        team_id="team-1",
+        supervisor_id="sup-1",
+        fields={"sentiment_below": 1.0, "min_occurrences": None, "window_days": None},
+    )
+
+    client.table.return_value.update.assert_called_once_with(
+        {
+            "sentiment_below": 1.0,
+            "min_occurrences": alert_helpers.DEFAULT_RECURRING_MIN_OCCURRENCES,
+            "window_days": alert_helpers.DEFAULT_RECURRING_WINDOW_DAYS,
+        }
     )
 
 
 def test_get_open_recurring_alert_normalizes_matched_value() -> None:
     """get_open_recurring_alert should normalize the matched value lookup."""
     client = MagicMock()
-    query = MagicMock()
     (
         client.table.return_value.select.return_value.eq.return_value.eq.return_value.eq.return_value.eq.return_value.eq.return_value.execute.return_value
     ) = SimpleNamespace(data=[{"id": "alert-1"}])
@@ -129,9 +157,9 @@ def test_get_open_recurring_alert_normalizes_matched_value() -> None:
 def test_update_alert_raises_not_found_for_missing_record() -> None:
     """update_alert should raise NotFoundError when no row matches the scope."""
     client = MagicMock()
-    client.table.return_value.update.return_value.eq.return_value.eq.return_value.eq.return_value.execute.return_value = SimpleNamespace(
-        data=[]
-    )
+    (
+        client.table.return_value.update.return_value.eq.return_value.eq.return_value.eq.return_value.execute.return_value
+    ) = SimpleNamespace(data=[])
 
     with pytest.raises(NotFoundError, match="Alert alert-404 not found"):
         alert_helpers.update_alert(

--- a/docs/database/datamodel-schema.md
+++ b/docs/database/datamodel-schema.md
@@ -215,6 +215,8 @@ Note: Each rule triggers independently (OR logic). So if a supervisor wants aler
 
 Note: `keyword` and `topic` values are normalized to lowercase in the app so matching stays consistent.
 
+Note: Manual alerts are not stored as rules. They are created directly in the `alerts` table by supervisors.
+
 ---
 
 ### 10. `alerts`
@@ -228,7 +230,7 @@ Note: `keyword` and `topic` values are normalized to lowercase in the app so mat
 | `rule_id` | **Foreign Key** → alert_configurations, nullable | Rule that generated the alert |
 | `supervisor_id` | **Foreign Key** → users | Alert recipient |
 | `team_id` | **Foreign Key** → teams | |
-| `type` | ENUM | `sentiment_threshold` · `keyword_match` · `recurring_topic` · `recurring_keyword` |
+| `type` | ENUM | `sentiment_threshold` · `keyword_match` · `recurring_topic` · `recurring_keyword` · `manual` |
 | `status` | ENUM | `open` · `closed` |
 | `severity` | ENUM | `low` · `medium` · `high` |
 | `title` | VARCHAR(255) | Alert headline |
@@ -390,7 +392,9 @@ user_role:  `agent`, `supervisor`
 
 sentiment_label:  `positive`, `neutral`, `negative`
 
-alert_type:  `sentiment_threshold`, `keyword_match`, `recurring_topic`, `recurring_keyword`
+alert_type:  `sentiment_threshold`, `keyword_match`, `recurring_topic`, `recurring_keyword`, `manual`
+
+Note: `alert_configurations.type` uses only the automated rule values. `manual` is used for supervisor-created alert rows in `alerts`.
 
 alert_status:  `open`, `closed`
 

--- a/docs/database/datamodel-schema.md
+++ b/docs/database/datamodel-schema.md
@@ -42,13 +42,13 @@ The idea behind this is to create a living document that would continue to be up
 
 ---
 
-## 💡 Entity Relationship Diagrams (ERDs)
+## Entity Relationship Diagrams (ERDs)
 
 ###  **[Click to see the ERDs](https://dbdiagram.io/d/AWS-Connect-Insights-698cc7c8bd82f5fce26e4beb)**
 
 ---
 
-## 💡 Table Definitions
+## Table Definitions
 
 ### 1. `users`
 
@@ -99,11 +99,11 @@ For insertion, we'd do the following:
 | `started_at` | TIMESTAMP | Call start time |
 | `created_at` | TIMESTAMP |  |
 
-💡 Team ID does seem redundant since we have agent ID and can get the information from the agent table but it could cause issues if the agent changes teams. This way all call history remains on the team.
+Note: Team ID does seem redundant since we have agent ID and can get the information from the agent table but it could cause issues if the agent changes teams. This way all call history remains on the team.
 
-💡 We also may not need an 'ended_at' field since we can just use calculate that on the frontend using duration + started_at
+Note: We also may not need an 'ended_at' field since we can just use calculate that on the frontend using duration + started_at.
 
-💡 Note: Transcript is now stored here (not in `call_analyses`) so we can re-run analysis without re-transcribing.
+Note: Transcript is now stored here (not in `call_analyses`) so we can re-run analysis without re-transcribing.
 
 ---
 
@@ -123,11 +123,11 @@ For insertion, we'd do the following:
 | `created_at` | TIMESTAMP |  |
 | `updated_at` | TIMESTAMP |  |
 
-💡 See `calls` table above as transcript has been moved there.
+Note: See `calls` table above as transcript has been moved there.
 
-💡 Another option is adding these fields directly in the calls table. The issue with that though would be that if we decide to change something major about our analysis, that would probably mess with our call records. So it might be better to have the call record separate and then store any analysis on it separately also.
+Note: Another option is adding these fields directly in the calls table. The issue with that though would be that if we decide to change something major about our analysis, that would probably mess with our call records. So it might be better to have the call record separate and then store any analysis on it separately also.
 
-💡 `key_moves` is stored here (not in `exemplar_calls`) so all calls have access to AI-identified techniques for coaching and pattern analysis.
+Note: `key_moves` is stored here (not in `exemplar_calls`) so all calls have access to AI-identified techniques for coaching and pattern analysis.
 
 ---
 
@@ -143,7 +143,7 @@ For insertion, we'd do the following:
 | `is_active` | BOOLEAN | Optional disable |
 | `created_at` | TIMESTAMP |  |
 
-💡 The optional disable exists in case we no longer need a tag and some other calls have already used it as deleting could cause issues.
+Note: The optional disable exists in case we no longer need a tag and some other calls have already used it as deleting could cause issues.
 
 
 ---
@@ -159,7 +159,7 @@ For insertion, we'd do the following:
 | `is_active` | BOOLEAN | Optional disable |
 | `created_at` | TIMESTAMP |  |
 
-💡 Mostly the same idea as the topic table.
+Note: Mostly the same idea as the topic table.
 
 ---
 
@@ -173,7 +173,7 @@ For insertion, we'd do the following:
 | `call_analysis_id` | **Foreign Key** → call_analyses |
 | `topic_id` | **Foreign Key** → topics |
 
-💡 Here we could alternatively use an enum instead and that'd mean adding them directly to the call table or even its own unique table. The issue would then be that if we wanted to filter by topics, we'd have to do an array search for all the rows in the table.
+Note: Here we could alternatively use an enum instead and that'd mean adding them directly to the call table or even its own unique table. The issue would then be that if we wanted to filter by topics, we'd have to do an array search for all the rows in the table.
 
 ---
 
@@ -187,52 +187,64 @@ For insertion, we'd do the following:
 | `call_analysis_id` | **Foreign Key** → call_analyses |
 | `keyword_id` | **Foreign Key** → keywords |
 
-💡 Same idea as  `call_analysis_topics`
+Note: Same idea as `call_analysis_topics`.
 
 ---
 
 ### 9. `alert_configurations`
 
-> Rules supervisors create to trigger alerts
+> Rules supervisors create to trigger alerts. The live schema now supports both call-level and recurring alert rules.
 
 | Column | Type | Description |
 |--------|------|-------------|
 | `id` | UUID, **Primary key** | |
 | `supervisor_id` | **Foreign Key** → users | Alert rule owner |
 | `team_id` | **Foreign Key** → teams | Applies to this team |
-| `type` | ENUM | `threshold` · `keyword` |
-| `sentiment_threshold` | DECIMAL | For threshold type |
-| `keyword_id` | **Foreign Key** → keywords | For keyword type |
+| `type` | ENUM | `sentiment_threshold` · `keyword_match` · `recurring_topic` · `recurring_keyword` |
+| `severity` | ENUM | `low` · `medium` · `high` |
+| `sentiment_below` | DECIMAL | Used by `sentiment_threshold` rules |
+| `keyword` | VARCHAR(100) | Used by `keyword_match` and `recurring_keyword` rules |
+| `topic` | VARCHAR(100) | Used by `recurring_topic` rules |
+| `min_occurrences` | INTEGER | Default `3`, used by recurring rules |
+| `window_days` | INTEGER | Default `7`, used by recurring rules |
 | `is_active` | BOOLEAN | Enable/disable |
 | `created_at` | TIMESTAMP | |
 | `updated_at` | TIMESTAMP | |
 
-💡 Each rule triggers independently (OR logic). So if a supervisor has settings of < 0.5 sentiments and keywords "negative" and "refund", we create 3 separate entries. This makes it easier to update if the supervisor decides to remove one of them and leave the rest.
+Note: Each rule triggers independently (OR logic). So if a supervisor wants alerts for sentiment below `-0.5`, keyword `"refund"`, and recurring topic `"cancellation"`, we create three separate rule rows.
+
+Note: `keyword` and `topic` values are normalized to lowercase in the app so matching stays consistent.
 
 ---
 
 ### 10. `alerts`
 
-> Generated when calls match alert rules (one alert per call max)
+> Generated when calls match alert rules. Alerts can point to a single call or represent a recurring pattern across multiple calls.
 
 | Column | Type | Description |
 |--------|------|-------------|
 | `id` | UUID, **Primary key** | |
-| `call_id` | **Foreign Key** → calls, UNIQUE | One alert per call |
+| `call_id` | **Foreign Key** → calls, nullable | Present for call-level alerts, null for recurring alerts |
+| `rule_id` | **Foreign Key** → alert_configurations, nullable | Rule that generated the alert |
 | `supervisor_id` | **Foreign Key** → users | Alert recipient |
 | `team_id` | **Foreign Key** → teams | |
-| `type` | ENUM | `threshold` · `keyword` · `manual` |
+| `type` | ENUM | `sentiment_threshold` · `keyword_match` · `recurring_topic` · `recurring_keyword` |
 | `status` | ENUM | `open` · `closed` |
 | `severity` | ENUM | `low` · `medium` · `high` |
 | `title` | VARCHAR(255) | Alert headline |
 | `description` | TEXT | Alert details |
 | `is_read` | BOOLEAN | Read status |
+| `matched_value` | VARCHAR(100) | Matching keyword or topic for recurring alerts |
+| `matched_count` | INTEGER | Number of matching calls inside the alert window |
+| `window_days` | INTEGER | Rolling window size for recurring alerts |
 | `created_at` | TIMESTAMP | |
 | `updated_at` | TIMESTAMP | |
 
-💡 Making call_id unique helps ensure we can only get one alert per call.
+Note: The live schema no longer enforces one alert per call globally. Instead, call-level alerts are deduped per `(rule_id, call_id)`, which means the same call can produce multiple alerts if it matches different rules.
 
-💡 **Severity calculation (standardized):** We can manually decide on ranges for call severity
+Note: Recurring alerts keep `call_id = NULL` because they summarize a pattern across several calls instead of pointing to one specific call.
+
+Note: Severity calculation is standardized by the backend rule configuration and alert generation flow.
 
 
 ---
@@ -250,11 +262,11 @@ For insertion, we'd do the following:
 | `note` | TEXT | Why it's a good example |
 | `created_at` | TIMESTAMP | |
 
-💡 We can get examplar calls transcript using a join on `call_id` → `calls.transcript`.
+Note: We can get examplar calls transcript using a join on `call_id` → `calls.transcript`.
 
-💡 `key_moves` is accessed via the call's analysis (`call_id` → `call_analyses.key_moves`), not stored here.
+Note: `key_moves` is accessed via the call's analysis (`call_id` → `call_analyses.key_moves`), not stored here.
 
-💡 Again, this could also be part of the calls table and is very much up for discussion but in light of trying to treat the calls table as the source of truth, this might be the better option since we also might want to add more content as to why the call is an examplar later on.
+Note: Again, this could also be part of the calls table and is very much up for discussion but in light of trying to treat the calls table as the source of truth, this might be the better option since we also might want to add more content as to why the call is an examplar later on.
 
 ---
 
@@ -275,7 +287,7 @@ For insertion, we'd do the following:
 | `dismissed` | BOOLEAN DEFAULT false | Agent can dismiss tips |
 | `created_at` | TIMESTAMP |  |
 
-💡 Content is stored as JSONB array to support multiple tips per coaching session.
+Note: Content is stored as JSONB array to support multiple tips per coaching session.
 
 ---
 
@@ -317,7 +329,7 @@ For insertion, we'd do the following:
 | `content` | JSONB | Full brief + exemplar IDs |
 | `created_at` | TIMESTAMP |  |
 
-💡 This would also store some AI generated content so using JSON may not be the best long term since some models might not follow the instructions. Putting the JSON as a place holder for now.
+Note: This would also store some AI generated content so using JSON may not be the best long term since some models might not follow the instructions. Putting the JSON as a place holder for now.
 
 ---
 
@@ -344,9 +356,9 @@ For insertion, we'd do the following:
 | `id` | UUID, **Primary key** | Auto-generated |
 | `transcript` | JSONB | Array of `{speaker, text}` objects |
 
-💡 This table stores standalone transcript samples that are not associated with actual calls. Used for simulation, testing, training, and development purposes. Format matches the `transcript` field in the `calls` table for consistency.
+Note: This table stores standalone transcript samples that are not associated with actual calls. Used for simulation, testing, training, and development purposes. Format matches the `transcript` field in the `calls` table for consistency.
 
-💡 The app picks one random sample transcript from this pool, then runs the canonical analysis flow to determine sentiment, topics, and coaching signals.
+Note: The app picks one random sample transcript from this pool, then runs the canonical analysis flow to determine sentiment, topics, and coaching signals.
 
 ---
 
@@ -361,7 +373,8 @@ For insertion, we'd do the following:
 | Analysis ↔ Topics | Many-to-Many |
 | Analysis ↔ Keywords | Many-to-Many |
 | Supervisor → Alert Configs | One-to-Many |
-| Call → Alert | One-to-One (optional) |
+| Alert Config → Alerts | One-to-Many |
+| Call → Alerts | One-to-Many (optional) |
 | Call → Exemplar | One-to-One (optional) |
 | Agent → Coaching Tips | One-to-Many |
 | User → Notifications | One-to-Many |
@@ -377,7 +390,7 @@ user_role:  `agent`, `supervisor`
 
 sentiment_label:  `positive`, `neutral`, `negative`
 
-alert_type:  `threshold`, `keyword`, `manual`
+alert_type:  `sentiment_threshold`, `keyword_match`, `recurring_topic`, `recurring_keyword`
 
 alert_status:  `open`, `closed`
 
@@ -390,7 +403,7 @@ notification_reference_type:  `call`, `alert`, `coaching_tip`, `exemplar_call`
 
 ---
 
-## 💡 Key Design Decisions
+## Key Design Decisions
 
 | Decision | Why |
 |----------|-----|
@@ -400,14 +413,14 @@ notification_reference_type:  `call`, `alert`, `coaching_tip`, `exemplar_call`
 
 ---
 
-## 💡 Open Questions
+## Open Questions
 
 - [ ] How  do we want to handle it when we delete a call and how do we handle all its other associated information?
 - [ ] Check for normalization and denormalization and make plan for how to handle them.
 - [ ] Calls currently are tied to a team meaning that if the user changes team that information starts to seem redundant
 - [ ] Decide on whether to add ended_at from the calls since that can be calculated using the started_at + duration
 - [ ] Thoughts on having call analysis as a separate table.
-- [x] For alerts status, just realized a boolean might even be simpler like is_read (RESOLVED)
+- [x] Alerts keep both `status` and `is_read`, since "closed" and "read" solve different problems
 - [ ] It does indeed seem like a lot of tables, so i'd love to hear thoughts and alternatives.
 
 ---

--- a/frontend/src/components/CallDetailDrawer.tsx
+++ b/frontend/src/components/CallDetailDrawer.tsx
@@ -26,8 +26,18 @@ import {
 } from 'lucide-react';
 import { toast } from '@/hooks/use-toast';
 
+type CallDetailCall = Call & {
+  callSummary?: {
+    callId: string;
+    summaryText: string;
+    keyPhrases: string[];
+    entities: string[];
+    transcript: Array<{ speaker: string; text: string; timestamp?: string }>;
+  };
+};
+
 interface CallDetailDrawerProps {
-  call: Call | null;
+  call: CallDetailCall | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
@@ -35,11 +45,12 @@ interface CallDetailDrawerProps {
 export function CallDetailDrawer({ call, open, onOpenChange }: CallDetailDrawerProps) {
   const [newNote, setNewNote] = useState('');
   const { user } = useAuthStore();
-  const { exemplarCallIds, toggleExemplar, callNotes, addNote, alerts, setAlerts } = useAppStore();
+  const { exemplarCallIds, toggleExemplar, callNotes, addNote } = useAppStore();
 
   if (!call) return null;
 
-  const summary = MockService.getSummary(call.id);
+  const summary: CallSummary | CallDetailCall['callSummary'] | undefined =
+    call.callSummary ?? MockService.getSummary(call.id);
   const isExemplar = exemplarCallIds.includes(call.id);
   const notes = callNotes.filter((n) => n.callId === call.id);
 
@@ -60,20 +71,9 @@ export function CallDetailDrawer({ call, open, onOpenChange }: CallDetailDrawerP
   };
 
   const handleCreateAlert = () => {
-    const newAlert = {
-      id: `alert-${Date.now()}`,
-      callId: call.id,
-      createdAt: new Date().toISOString(),
-      ruleId: 'manual',
-      ruleLabel: 'Manual Review',
-      severity: 'medium' as const,
-      status: 'open' as const,
-      issue: `Manual alert for ${call.topics[0]} call`,
-    };
-    setAlerts([newAlert, ...alerts]);
     toast({
-      title: 'Alert Created',
-      description: 'A new alert has been created for this call.',
+      title: 'Manual Alerts Coming Soon',
+      description: 'Manual alert creation has not been wired to the backend yet.',
     });
   };
 
@@ -82,7 +82,7 @@ export function CallDetailDrawer({ call, open, onOpenChange }: CallDetailDrawerP
     addNote({
       callId: call.id,
       userId: user.id,
-      userName: user.name,
+      userName: `${user.firstName} ${user.lastName}`.trim() || user.email,
       text: newNote.trim(),
     });
     setNewNote('');
@@ -200,9 +200,11 @@ export function CallDetailDrawer({ call, open, onOpenChange }: CallDetailDrawerP
                     >
                       <div className="flex items-center gap-2 mb-1">
                         <span className="text-xs font-medium">{turn.speaker}</span>
-                        <span className="text-xs text-muted-foreground">
-                          {turn.timestamp}
-                        </span>
+                        {turn.timestamp && (
+                          <span className="text-xs text-muted-foreground">
+                            {turn.timestamp}
+                          </span>
+                        )}
                       </div>
                       <p className="text-sm">{turn.text}</p>
                     </div>

--- a/frontend/src/components/CallDetailDrawer.tsx
+++ b/frontend/src/components/CallDetailDrawer.tsx
@@ -27,6 +27,8 @@ import {
 import { toast } from '@/hooks/use-toast';
 
 type CallDetailCall = Call & {
+  hasOpenAlert?: boolean;
+  openAlertId?: string | null;
   callSummary?: {
     callId: string;
     summaryText: string;
@@ -40,9 +42,19 @@ interface CallDetailDrawerProps {
   call: CallDetailCall | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  canCreateAlert?: boolean;
+  isCreatingAlert?: boolean;
+  onCreateAlert?: (callId: string) => Promise<void>;
 }
 
-export function CallDetailDrawer({ call, open, onOpenChange }: CallDetailDrawerProps) {
+export function CallDetailDrawer({
+  call,
+  open,
+  onOpenChange,
+  canCreateAlert = false,
+  isCreatingAlert = false,
+  onCreateAlert,
+}: CallDetailDrawerProps) {
   const [newNote, setNewNote] = useState('');
   const { user } = useAuthStore();
   const { exemplarCallIds, toggleExemplar, callNotes, addNote } = useAppStore();
@@ -70,11 +82,9 @@ export function CallDetailDrawer({ call, open, onOpenChange }: CallDetailDrawerP
     });
   };
 
-  const handleCreateAlert = () => {
-    toast({
-      title: 'Manual Alerts Coming Soon',
-      description: 'Manual alert creation has not been wired to the backend yet.',
-    });
+  const handleCreateAlert = async () => {
+    if (!onCreateAlert) return;
+    await onCreateAlert(call.id);
   };
 
   const handleAddNote = () => {
@@ -259,10 +269,17 @@ export function CallDetailDrawer({ call, open, onOpenChange }: CallDetailDrawerP
                 <Star className={`h-4 w-4 mr-2 ${isExemplar ? 'fill-current' : ''}`} />
                 {isExemplar ? 'Remove Exemplar' : 'Mark as Exemplar'}
               </Button>
-              <Button variant="outline" size="sm" onClick={handleCreateAlert}>
-                <AlertTriangle className="h-4 w-4 mr-2" />
-                Create Alert
-              </Button>
+              {canCreateAlert && !call.hasOpenAlert && onCreateAlert && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void handleCreateAlert()}
+                  disabled={isCreatingAlert}
+                >
+                  <AlertTriangle className="h-4 w-4 mr-2" />
+                  {isCreatingAlert ? 'Creating Alert...' : 'Create Alert'}
+                </Button>
+              )}
             </div>
           </div>
         </ScrollArea>

--- a/frontend/src/components/__tests__/CallDetailDrawer.test.tsx
+++ b/frontend/src/components/__tests__/CallDetailDrawer.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CallDetailDrawer } from '../CallDetailDrawer';
+
+const baseCall = {
+  id: 'call-1',
+  agentId: 'agent-1',
+  agentName: 'Ada Lovelace',
+  startedAt: '2026-04-02T12:00:00Z',
+  durationSec: 240,
+  sentimentScore: -0.3,
+  sentimentLabel: 'negative' as const,
+  topics: ['refund'],
+  resolved: false,
+  csat: null,
+  customerName: 'Customer',
+  callSummary: {
+    callId: 'call-1',
+    summaryText: 'Customer requested a refund.',
+    keyPhrases: ['refund'],
+    entities: ['Ada Lovelace'],
+    transcript: [{ speaker: 'Customer', text: 'I want a refund.' }],
+  },
+};
+
+describe('CallDetailDrawer', () => {
+  it('shows manual alert action when creation is enabled and the call has no open alert', () => {
+    render(
+      <CallDetailDrawer
+        call={{ ...baseCall, hasOpenAlert: false, openAlertId: null }}
+        open
+        onOpenChange={vi.fn()}
+        canCreateAlert
+        onCreateAlert={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Create Alert' })).toBeInTheDocument();
+  });
+
+  it('hides manual alert action when the call already has an open alert', () => {
+    render(
+      <CallDetailDrawer
+        call={{ ...baseCall, hasOpenAlert: true, openAlertId: 'alert-1' }}
+        open
+        onOpenChange={vi.fn()}
+        canCreateAlert
+        onCreateAlert={vi.fn().mockResolvedValue(undefined)}
+      />
+    );
+
+    expect(screen.queryByRole('button', { name: 'Create Alert' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/__tests__/api.alerts.test.ts
+++ b/frontend/src/lib/__tests__/api.alerts.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import {
+  alertsApi,
+  callsApi,
+  type SupervisorAlertRecord,
+  type SupervisorAlertRule,
+  type SupervisorCallDetail,
+} from '../api';
+import { server } from '@/test/mocks/server';
+
+describe('alerts api client', () => {
+  it('lists alerts with query params', async () => {
+    server.use(
+      http.get('http://localhost:8000/api/alerts', ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get('status')).toBe('open');
+        expect(url.searchParams.get('per_page')).toBe('5');
+
+        return HttpResponse.json({
+          alerts: [
+            {
+              id: 'alert-1',
+              rule_id: 'rule-1',
+              type: 'sentiment_threshold',
+              severity: 'high',
+              status: 'open',
+              is_read: false,
+              call_id: 'call-1',
+              matched_value: null,
+              matched_count: null,
+              window_days: null,
+              title: 'Negative sentiment threshold breached',
+              description: 'A tracked alert fired.',
+              created_at: '2026-04-02T12:00:00Z',
+              updated_at: '2026-04-02T12:00:00Z',
+            } satisfies SupervisorAlertRecord,
+          ],
+          total: 1,
+          page: 1,
+          per_page: 5,
+        });
+      })
+    );
+
+    const response = await alertsApi.listAlerts({ status: 'open', per_page: 5 });
+    expect(response.total).toBe(1);
+    expect(response.alerts[0].id).toBe('alert-1');
+  });
+
+  it('creates and updates rules and fetches call detail', async () => {
+    server.use(
+      http.post('http://localhost:8000/api/alerts/rules', async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        expect(body).toMatchObject({
+          type: 'keyword_match',
+          severity: 'high',
+          keyword: 'refund',
+        });
+
+        return HttpResponse.json(
+          {
+            id: 'rule-1',
+            type: 'keyword_match',
+            severity: 'high',
+            is_active: true,
+            team_id: 'team-1',
+            supervisor_id: 'sup-1',
+            sentiment_below: null,
+            keyword: 'refund',
+            topic: null,
+            min_occurrences: null,
+            window_days: null,
+            created_at: '2026-04-02T12:00:00Z',
+            updated_at: '2026-04-02T12:00:00Z',
+          } satisfies SupervisorAlertRule,
+          { status: 201 }
+        );
+      }),
+      http.patch('http://localhost:8000/api/alerts/rules/rule-1', async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        expect(body).toMatchObject({ is_active: false });
+
+        return HttpResponse.json({
+          id: 'rule-1',
+          type: 'keyword_match',
+          severity: 'high',
+          is_active: false,
+          team_id: 'team-1',
+          supervisor_id: 'sup-1',
+          sentiment_below: null,
+          keyword: 'refund',
+          topic: null,
+          min_occurrences: null,
+          window_days: null,
+          created_at: '2026-04-02T12:00:00Z',
+          updated_at: '2026-04-02T12:01:00Z',
+        } satisfies SupervisorAlertRule);
+      }),
+      http.get('http://localhost:8000/api/calls/call-1', () =>
+        HttpResponse.json({
+          id: 'call-1',
+          agent_id: 'agent-1',
+          agent_name: 'Ada Lovelace',
+          started_at: '2026-04-02T12:00:00Z',
+          duration_seconds: 240,
+          sentiment_score: -0.3,
+          sentiment_label: 'negative',
+          is_resolved: false,
+          topics: ['refund'],
+          summary: 'Customer requested a refund.',
+          transcript: [{ speaker: 'Customer', text: 'I need a refund.' }],
+        } satisfies SupervisorCallDetail)
+      )
+    );
+
+    const createdRule = await alertsApi.createRule({
+      type: 'keyword_match',
+      severity: 'high',
+      keyword: 'refund',
+      is_active: true,
+    });
+    expect(createdRule.id).toBe('rule-1');
+
+    const updatedRule = await alertsApi.updateRule('rule-1', { is_active: false });
+    expect(updatedRule.is_active).toBe(false);
+
+    const call = await callsApi.getCallById('call-1');
+    expect(call.agent_name).toBe('Ada Lovelace');
+  });
+});

--- a/frontend/src/lib/__tests__/api.alerts.test.ts
+++ b/frontend/src/lib/__tests__/api.alerts.test.ts
@@ -109,8 +109,55 @@ describe('alerts api client', () => {
           is_resolved: false,
           topics: ['refund'],
           summary: 'Customer requested a refund.',
+          has_open_alert: true,
+          open_alert_id: 'alert-1',
           transcript: [{ speaker: 'Customer', text: 'I need a refund.' }],
         } satisfies SupervisorCallDetail)
+      ),
+      http.post('http://localhost:8000/api/alerts/manual', async ({ request }) => {
+        const body = (await request.json()) as Record<string, unknown>;
+        expect(body).toMatchObject({ call_id: 'call-1' });
+
+        return HttpResponse.json(
+          {
+            id: 'alert-1',
+            rule_id: null,
+            type: 'manual',
+            severity: 'medium',
+            status: 'open',
+            is_read: false,
+            call_id: 'call-1',
+            matched_value: null,
+            matched_count: null,
+            window_days: null,
+            title: 'Manual review requested',
+            description: 'Supervisor manually flagged the call for review.',
+            created_at: '2026-04-02T12:00:00Z',
+            updated_at: '2026-04-02T12:00:00Z',
+          } satisfies SupervisorAlertRecord,
+          { status: 201 }
+        );
+      }),
+      http.get('http://localhost:8000/api/alerts/alert-1/calls', () =>
+        HttpResponse.json({
+          calls: [
+            {
+              id: 'call-1',
+              agent_id: 'agent-1',
+              agent_name: 'Ada Lovelace',
+              started_at: '2026-04-02T12:00:00Z',
+              duration_seconds: 240,
+              sentiment_score: -0.3,
+              sentiment_label: 'negative',
+              is_resolved: false,
+              topics: ['refund'],
+              summary: 'Customer requested a refund.',
+              has_open_alert: true,
+              open_alert_id: 'alert-1',
+              transcript: [{ speaker: 'Customer', text: 'I need a refund.' }],
+            } satisfies SupervisorCallDetail,
+          ],
+        })
       )
     );
 
@@ -127,5 +174,12 @@ describe('alerts api client', () => {
 
     const call = await callsApi.getCallById('call-1');
     expect(call.agent_name).toBe('Ada Lovelace');
+    expect(call.has_open_alert).toBe(true);
+
+    const manualAlert = await alertsApi.createManualAlert({ call_id: 'call-1' });
+    expect(manualAlert.type).toBe('manual');
+
+    const relatedCalls = await alertsApi.listAlertCalls('alert-1');
+    expect(relatedCalls.calls).toHaveLength(1);
   });
 });

--- a/frontend/src/lib/__tests__/supervisor-alerts.test.ts
+++ b/frontend/src/lib/__tests__/supervisor-alerts.test.ts
@@ -27,6 +27,7 @@ describe('supervisor alerts adapters', () => {
       })
     ).toEqual({
       id: 'alert-1',
+      type: 'sentiment_threshold',
       callId: 'call-1',
       createdAt: '2026-04-02T12:00:00Z',
       ruleId: 'rule-1',
@@ -34,6 +35,9 @@ describe('supervisor alerts adapters', () => {
       severity: 'high',
       status: 'open',
       issue: 'Call sentiment score -0.70 fell below the configured threshold.',
+      matchedValue: null,
+      matchedCount: null,
+      windowDays: null,
     });
   });
 
@@ -50,6 +54,8 @@ describe('supervisor alerts adapters', () => {
         is_resolved: false,
         topics: ['refund'],
         summary: 'Customer requested a refund.',
+        has_open_alert: true,
+        open_alert_id: 'alert-1',
         transcript: [{ speaker: 'Customer', text: 'I want a refund.', timestamp: null }],
       })
     ).toMatchObject({
@@ -63,6 +69,8 @@ describe('supervisor alerts adapters', () => {
       topics: ['refund'],
       resolved: false,
       customerName: 'Customer',
+      hasOpenAlert: true,
+      openAlertId: 'alert-1',
       callSummary: {
         summaryText: 'Customer requested a refund.',
         keyPhrases: ['refund'],

--- a/frontend/src/lib/__tests__/supervisor-alerts.test.ts
+++ b/frontend/src/lib/__tests__/supervisor-alerts.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveAlertSettingsViewModel,
+  mapAlertRecordToViewModel,
+  mapCallDetailToViewModel,
+  normalizeKeywordInput,
+} from '../supervisor-alerts';
+
+describe('supervisor alerts adapters', () => {
+  it('maps backend alert records into the existing alert view model', () => {
+    expect(
+      mapAlertRecordToViewModel({
+        id: 'alert-1',
+        rule_id: 'rule-1',
+        type: 'sentiment_threshold',
+        severity: 'high',
+        status: 'open',
+        is_read: false,
+        call_id: 'call-1',
+        matched_value: null,
+        matched_count: null,
+        window_days: null,
+        title: 'Negative sentiment threshold breached',
+        description: 'Call sentiment score -0.70 fell below the configured threshold.',
+        created_at: '2026-04-02T12:00:00Z',
+        updated_at: '2026-04-02T12:00:00Z',
+      })
+    ).toEqual({
+      id: 'alert-1',
+      callId: 'call-1',
+      createdAt: '2026-04-02T12:00:00Z',
+      ruleId: 'rule-1',
+      ruleLabel: 'Negative sentiment threshold breached',
+      severity: 'high',
+      status: 'open',
+      issue: 'Call sentiment score -0.70 fell below the configured threshold.',
+    });
+  });
+
+  it('maps backend call detail into the drawer-friendly call shape', () => {
+    expect(
+      mapCallDetailToViewModel({
+        id: 'call-1',
+        agent_id: 'agent-1',
+        agent_name: 'Ada Lovelace',
+        started_at: '2026-04-02T12:00:00Z',
+        duration_seconds: 240,
+        sentiment_score: -0.3,
+        sentiment_label: 'negative',
+        is_resolved: false,
+        topics: ['refund'],
+        summary: 'Customer requested a refund.',
+        transcript: [{ speaker: 'Customer', text: 'I want a refund.', timestamp: null }],
+      })
+    ).toMatchObject({
+      id: 'call-1',
+      agentId: 'agent-1',
+      agentName: 'Ada Lovelace',
+      startedAt: '2026-04-02T12:00:00Z',
+      durationSec: 240,
+      sentimentScore: -0.3,
+      sentimentLabel: 'negative',
+      topics: ['refund'],
+      resolved: false,
+      customerName: 'Customer',
+      callSummary: {
+        summaryText: 'Customer requested a refund.',
+        keyPhrases: ['refund'],
+      },
+    });
+  });
+
+  it('derives canonical threshold and active keywords from rules', () => {
+    const derived = deriveAlertSettingsViewModel([
+      {
+        id: 'rule-new',
+        type: 'sentiment_threshold',
+        severity: 'high',
+        is_active: true,
+        team_id: 'team-1',
+        supervisor_id: 'sup-1',
+        sentiment_below: -0.4,
+        keyword: null,
+        topic: null,
+        min_occurrences: null,
+        window_days: null,
+        created_at: '2026-04-02T12:00:00Z',
+        updated_at: '2026-04-02T12:00:00Z',
+      },
+      {
+        id: 'rule-old',
+        type: 'sentiment_threshold',
+        severity: 'high',
+        is_active: true,
+        team_id: 'team-1',
+        supervisor_id: 'sup-1',
+        sentiment_below: -0.6,
+        keyword: null,
+        topic: null,
+        min_occurrences: null,
+        window_days: null,
+        created_at: '2026-04-01T12:00:00Z',
+        updated_at: '2026-04-01T12:00:00Z',
+      },
+      {
+        id: 'keyword-1',
+        type: 'keyword_match',
+        severity: 'high',
+        is_active: true,
+        team_id: 'team-1',
+        supervisor_id: 'sup-1',
+        sentiment_below: null,
+        keyword: 'refund',
+        topic: null,
+        min_occurrences: null,
+        window_days: null,
+        created_at: '2026-04-02T12:00:00Z',
+        updated_at: '2026-04-02T12:00:00Z',
+      },
+      {
+        id: 'ignored-recurring',
+        type: 'recurring_keyword',
+        severity: 'medium',
+        is_active: true,
+        team_id: 'team-1',
+        supervisor_id: 'sup-1',
+        sentiment_below: null,
+        keyword: 'chargeback',
+        topic: null,
+        min_occurrences: 3,
+        window_days: 7,
+        created_at: '2026-04-02T12:00:00Z',
+        updated_at: '2026-04-02T12:00:00Z',
+      },
+    ]);
+
+    expect(derived.thresholdRule?.id).toBe('rule-new');
+    expect(derived.duplicateThresholdRules.map((rule) => rule.id)).toEqual(['rule-old']);
+    expect(derived.keywords).toEqual(['refund']);
+  });
+
+  it('normalizes keyword input', () => {
+    expect(normalizeKeywordInput(' Refund ')).toBe('refund');
+    expect(normalizeKeywordInput('   ')).toBeNull();
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -259,6 +259,128 @@ export const dashboardApi = {
 };
 
 // =============================================================================
+// Alerts API Types
+// =============================================================================
+
+export type SupervisorAlertSeverity = 'low' | 'medium' | 'high';
+export type SupervisorAlertStatus = 'open' | 'closed';
+export type SupervisorAlertType =
+  | 'sentiment_threshold'
+  | 'keyword_match'
+  | 'recurring_topic'
+  | 'recurring_keyword';
+
+export interface SupervisorAlertRecord {
+  id: string;
+  rule_id: string | null;
+  type: SupervisorAlertType;
+  severity: SupervisorAlertSeverity;
+  status: SupervisorAlertStatus;
+  is_read: boolean;
+  call_id: string | null;
+  matched_value: string | null;
+  matched_count: number | null;
+  window_days: number | null;
+  title: string;
+  description: string;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface SupervisorAlertsListResponse {
+  alerts: SupervisorAlertRecord[];
+  total: number;
+  page: number;
+  per_page: number;
+}
+
+export interface SupervisorAlertPatchRequest {
+  status?: SupervisorAlertStatus;
+  is_read?: boolean;
+}
+
+export interface SupervisorAlertRule {
+  id: string;
+  type: SupervisorAlertType;
+  severity: SupervisorAlertSeverity;
+  is_active: boolean;
+  team_id: string;
+  supervisor_id: string;
+  sentiment_below: number | null;
+  keyword: string | null;
+  topic: string | null;
+  min_occurrences: number | null;
+  window_days: number | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface SupervisorAlertRulesListResponse {
+  rules: SupervisorAlertRule[];
+}
+
+export interface CreateSupervisorAlertRuleRequest {
+  type: SupervisorAlertType;
+  severity: SupervisorAlertSeverity;
+  is_active?: boolean;
+  sentiment_below?: number;
+  keyword?: string;
+  topic?: string;
+  min_occurrences?: number;
+  window_days?: number;
+}
+
+export interface UpdateSupervisorAlertRuleRequest {
+  type?: SupervisorAlertType;
+  severity?: SupervisorAlertSeverity;
+  is_active?: boolean;
+  sentiment_below?: number;
+  keyword?: string;
+  topic?: string;
+  min_occurrences?: number;
+  window_days?: number;
+}
+
+// =============================================================================
+// Alerts API
+// =============================================================================
+
+function toQueryString(params: Record<string, string | number | boolean | undefined>) {
+  const search = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined) {
+      search.set(key, String(value));
+    }
+  });
+  const query = search.toString();
+  return query ? `?${query}` : '';
+}
+
+export const alertsApi = {
+  listAlerts: (params: {
+    status?: SupervisorAlertStatus;
+    severity?: SupervisorAlertSeverity;
+    type?: SupervisorAlertType;
+    is_read?: boolean;
+    page?: number;
+    per_page?: number;
+  } = {}) =>
+    api.get<SupervisorAlertsListResponse>(`/api/alerts${toQueryString(params)}`),
+
+  updateAlert: (alertId: string, data: SupervisorAlertPatchRequest) =>
+    api.patch<SupervisorAlertRecord>(`/api/alerts/${alertId}`, data),
+
+  listRules: (params: { is_active?: boolean } = {}) =>
+    api.get<SupervisorAlertRulesListResponse>(`/api/alerts/rules${toQueryString(params)}`),
+
+  createRule: (data: CreateSupervisorAlertRuleRequest) =>
+    api.post<SupervisorAlertRule>('/api/alerts/rules', data),
+
+  updateRule: (ruleId: string, data: UpdateSupervisorAlertRuleRequest) =>
+    api.patch<SupervisorAlertRule>(`/api/alerts/rules/${ruleId}`, data),
+};
+
+// =============================================================================
 // Calls API Types
 // =============================================================================
 
@@ -278,11 +400,32 @@ export interface SimulateCallResponse {
   keywords: Record<string, boolean>;
 }
 
+export interface SupervisorCallDetail {
+  id: string;
+  agent_id: string;
+  agent_name: string;
+  started_at: string | null;
+  duration_seconds: number | null;
+  sentiment_score: number | null;
+  sentiment_label: 'positive' | 'neutral' | 'negative' | null;
+  is_resolved: boolean | null;
+  topics: string[];
+  summary: string | null;
+  transcript: Array<{
+    speaker: string;
+    text: string;
+    timestamp?: string | null;
+  }>;
+}
+
 // =============================================================================
 // Calls API
 // =============================================================================
 
 export const callsApi = {
+  getCallById: (callId: string) =>
+    api.get<SupervisorCallDetail>(`/api/calls/${callId}`),
+
   simulateCall: () =>
     api.post<SimulateCallResponse>('/api/calls/simulate'),
 };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -264,11 +264,12 @@ export const dashboardApi = {
 
 export type SupervisorAlertSeverity = 'low' | 'medium' | 'high';
 export type SupervisorAlertStatus = 'open' | 'closed';
-export type SupervisorAlertType =
+export type SupervisorAlertRuleType =
   | 'sentiment_threshold'
   | 'keyword_match'
   | 'recurring_topic'
   | 'recurring_keyword';
+export type SupervisorAlertType = SupervisorAlertRuleType | 'manual';
 
 export interface SupervisorAlertRecord {
   id: string;
@@ -299,9 +300,13 @@ export interface SupervisorAlertPatchRequest {
   is_read?: boolean;
 }
 
+export interface CreateManualAlertRequest {
+  call_id: string;
+}
+
 export interface SupervisorAlertRule {
   id: string;
-  type: SupervisorAlertType;
+  type: SupervisorAlertRuleType;
   severity: SupervisorAlertSeverity;
   is_active: boolean;
   team_id: string;
@@ -319,8 +324,12 @@ export interface SupervisorAlertRulesListResponse {
   rules: SupervisorAlertRule[];
 }
 
+export interface SupervisorAlertCallsResponse {
+  calls: SupervisorCallDetail[];
+}
+
 export interface CreateSupervisorAlertRuleRequest {
-  type: SupervisorAlertType;
+  type: SupervisorAlertRuleType;
   severity: SupervisorAlertSeverity;
   is_active?: boolean;
   sentiment_below?: number;
@@ -331,7 +340,7 @@ export interface CreateSupervisorAlertRuleRequest {
 }
 
 export interface UpdateSupervisorAlertRuleRequest {
-  type?: SupervisorAlertType;
+  type?: SupervisorAlertRuleType;
   severity?: SupervisorAlertSeverity;
   is_active?: boolean;
   sentiment_below?: number;
@@ -369,6 +378,12 @@ export const alertsApi = {
 
   updateAlert: (alertId: string, data: SupervisorAlertPatchRequest) =>
     api.patch<SupervisorAlertRecord>(`/api/alerts/${alertId}`, data),
+
+  createManualAlert: (data: CreateManualAlertRequest) =>
+    api.post<SupervisorAlertRecord>('/api/alerts/manual', data),
+
+  listAlertCalls: (alertId: string) =>
+    api.get<SupervisorAlertCallsResponse>(`/api/alerts/${alertId}/calls`),
 
   listRules: (params: { is_active?: boolean } = {}) =>
     api.get<SupervisorAlertRulesListResponse>(`/api/alerts/rules${toQueryString(params)}`),
@@ -411,6 +426,8 @@ export interface SupervisorCallDetail {
   is_resolved: boolean | null;
   topics: string[];
   summary: string | null;
+  has_open_alert: boolean;
+  open_alert_id: string | null;
   transcript: Array<{
     speaker: string;
     text: string;

--- a/frontend/src/lib/mock-service.ts
+++ b/frontend/src/lib/mock-service.ts
@@ -1,4 +1,4 @@
-import { mockData, Call, Alert, CallSummary } from './mock-data';
+import { mockData, Call, CallSummary } from './mock-data';
 import { useAppStore } from '@/stores/app-store';
 import jsPDF from 'jspdf';
 import html2canvas from 'html2canvas';
@@ -71,31 +71,6 @@ export const MockService = {
 
   getSummary(callId: string): CallSummary | undefined {
     return mockData.getSummary(callId);
-  },
-
-  listAlerts(filters?: {
-    status?: 'open' | 'closed';
-    severity?: 'high' | 'medium' | 'low';
-    ruleLabel?: string;
-    dateFrom?: string;
-    dateTo?: string;
-  }): Alert[] {
-    const storeAlerts = useAppStore.getState().alerts;
-    const alerts = storeAlerts.length > 0 ? storeAlerts : mockData.alerts;
-    
-    return alerts.filter((alert) => {
-      if (filters?.status && alert.status !== filters.status) return false;
-      if (filters?.severity && alert.severity !== filters.severity) return false;
-      if (filters?.ruleLabel && alert.ruleLabel !== filters.ruleLabel) return false;
-      if (filters?.dateFrom && alert.createdAt < filters.dateFrom) return false;
-      if (filters?.dateTo && alert.createdAt > filters.dateTo) return false;
-      return true;
-    });
-  },
-
-  mutateAlert(alertId: string, patch: Partial<Alert>): Alert | undefined {
-    useAppStore.getState().updateAlert(alertId, patch);
-    return useAppStore.getState().alerts.find((a) => a.id === alertId);
   },
 
   generateDailyBrief(date: string) {

--- a/frontend/src/lib/seed.ts
+++ b/frontend/src/lib/seed.ts
@@ -1,4 +1,3 @@
-import { mockData } from './mock-data';
 import { useAppStore } from '@/stores/app-store';
 
 const SEEDED_KEY = 'demo-data-seeded';
@@ -8,13 +7,6 @@ export function seedInitialData(force = false): void {
   
   if (alreadySeeded && !force) {
     return;
-  }
-
-  const store = useAppStore.getState();
-  
-  // Seed alerts from mock data
-  if (store.alerts.length === 0 || force) {
-    store.setAlerts(mockData.alerts);
   }
 
   // Mark as seeded
@@ -31,4 +23,3 @@ export function resetAndReseed(): void {
   // Re-seed with fresh data
   seedInitialData(true);
 }
-

--- a/frontend/src/lib/supervisor-alerts.ts
+++ b/frontend/src/lib/supervisor-alerts.ts
@@ -1,0 +1,129 @@
+import type {
+  SupervisorAlertRecord,
+  SupervisorAlertRule,
+  SupervisorCallDetail,
+} from '@/lib/api';
+
+export type SupervisorSentimentLabel = 'positive' | 'neutral' | 'negative';
+
+export interface SupervisorAlertViewModel {
+  id: string;
+  callId: string | null;
+  createdAt: string;
+  ruleId: string;
+  ruleLabel: string;
+  severity: 'high' | 'medium' | 'low';
+  status: 'open' | 'closed';
+  issue: string;
+}
+
+export interface SupervisorCallSummaryViewModel {
+  callId: string;
+  summaryText: string;
+  keyPhrases: string[];
+  entities: string[];
+  transcript: Array<{ speaker: string; text: string; timestamp?: string }>;
+}
+
+export interface SupervisorCallViewModel {
+  id: string;
+  agentId: string;
+  agentName: string;
+  startedAt: string;
+  durationSec: number;
+  sentimentScore: number;
+  sentimentLabel: SupervisorSentimentLabel;
+  topics: string[];
+  resolved: boolean;
+  csat: number | null;
+  customerName: string;
+  callSummary?: SupervisorCallSummaryViewModel;
+}
+
+export interface SupervisorAlertSettingsViewModel {
+  thresholdRule: SupervisorAlertRule | null;
+  duplicateThresholdRules: SupervisorAlertRule[];
+  keywordRules: SupervisorAlertRule[];
+  keywords: string[];
+}
+
+export function normalizeKeywordInput(value: string): string | null {
+  const normalized = value.trim().toLowerCase();
+  return normalized || null;
+}
+
+export function mapAlertRecordToViewModel(
+  record: SupervisorAlertRecord,
+): SupervisorAlertViewModel {
+  return {
+    id: record.id,
+    callId: record.call_id,
+    createdAt: record.created_at ?? '',
+    ruleId: record.rule_id ?? record.id,
+    ruleLabel: record.title,
+    severity: record.severity,
+    status: record.status,
+    issue: record.description,
+  };
+}
+
+export function mapCallDetailToViewModel(
+  detail: SupervisorCallDetail,
+): SupervisorCallViewModel {
+  const topics = detail.topics ?? [];
+  const transcript = (detail.transcript ?? []).map((turn) => ({
+    speaker: turn.speaker,
+    text: turn.text,
+    timestamp: turn.timestamp ?? undefined,
+  }));
+
+  return {
+    id: detail.id,
+    agentId: detail.agent_id,
+    agentName: detail.agent_name,
+    startedAt: detail.started_at ?? '',
+    durationSec: detail.duration_seconds ?? 0,
+    sentimentScore: detail.sentiment_score ?? 0,
+    sentimentLabel: detail.sentiment_label ?? 'neutral',
+    topics,
+    resolved: detail.is_resolved ?? false,
+    csat: null,
+    customerName: 'Customer',
+    callSummary: detail.summary
+      ? {
+          callId: detail.id,
+          summaryText: detail.summary,
+          keyPhrases: topics.slice(0, 5),
+          entities: [detail.agent_name],
+          transcript,
+        }
+      : transcript.length > 0
+        ? {
+            callId: detail.id,
+            summaryText: 'Transcript available for this call.',
+            keyPhrases: topics.slice(0, 5),
+            entities: [detail.agent_name],
+            transcript,
+          }
+        : undefined,
+  };
+}
+
+export function deriveAlertSettingsViewModel(
+  rules: SupervisorAlertRule[],
+): SupervisorAlertSettingsViewModel {
+  const activeRules = rules.filter((rule) => rule.is_active);
+  const thresholdRules = activeRules.filter((rule) => rule.type === 'sentiment_threshold');
+  const keywordRules = activeRules.filter((rule) => rule.type === 'keyword_match');
+
+  const [thresholdRule, ...duplicateThresholdRules] = thresholdRules;
+
+  return {
+    thresholdRule: thresholdRule ?? null,
+    duplicateThresholdRules,
+    keywordRules,
+    keywords: keywordRules
+      .map((rule) => normalizeKeywordInput(rule.keyword ?? ''))
+      .filter((keyword): keyword is string => Boolean(keyword)),
+  };
+}

--- a/frontend/src/lib/supervisor-alerts.ts
+++ b/frontend/src/lib/supervisor-alerts.ts
@@ -8,6 +8,7 @@ export type SupervisorSentimentLabel = 'positive' | 'neutral' | 'negative';
 
 export interface SupervisorAlertViewModel {
   id: string;
+  type: 'sentiment_threshold' | 'keyword_match' | 'recurring_topic' | 'recurring_keyword' | 'manual';
   callId: string | null;
   createdAt: string;
   ruleId: string;
@@ -15,6 +16,9 @@ export interface SupervisorAlertViewModel {
   severity: 'high' | 'medium' | 'low';
   status: 'open' | 'closed';
   issue: string;
+  matchedValue: string | null;
+  matchedCount: number | null;
+  windowDays: number | null;
 }
 
 export interface SupervisorCallSummaryViewModel {
@@ -38,6 +42,8 @@ export interface SupervisorCallViewModel {
   csat: number | null;
   customerName: string;
   callSummary?: SupervisorCallSummaryViewModel;
+  hasOpenAlert: boolean;
+  openAlertId: string | null;
 }
 
 export interface SupervisorAlertSettingsViewModel {
@@ -57,6 +63,7 @@ export function mapAlertRecordToViewModel(
 ): SupervisorAlertViewModel {
   return {
     id: record.id,
+    type: record.type,
     callId: record.call_id,
     createdAt: record.created_at ?? '',
     ruleId: record.rule_id ?? record.id,
@@ -64,6 +71,9 @@ export function mapAlertRecordToViewModel(
     severity: record.severity,
     status: record.status,
     issue: record.description,
+    matchedValue: record.matched_value,
+    matchedCount: record.matched_count,
+    windowDays: record.window_days,
   };
 }
 
@@ -89,6 +99,8 @@ export function mapCallDetailToViewModel(
     resolved: detail.is_resolved ?? false,
     csat: null,
     customerName: 'Customer',
+    hasOpenAlert: detail.has_open_alert,
+    openAlertId: detail.open_alert_id,
     callSummary: detail.summary
       ? {
           callId: detail.id,

--- a/frontend/src/pages/supervisor/Alerts.tsx
+++ b/frontend/src/pages/supervisor/Alerts.tsx
@@ -1,50 +1,115 @@
-import { useState, useEffect, useMemo } from 'react';
-import { mockData } from '@/lib/mock-data';
-import type { Call } from '@/lib/mock-data';
-import { useAppStore } from '@/stores/app-store';
+import { useMemo, useState } from 'react';
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { alertsApi, callsApi, type SupervisorAlertSeverity, type SupervisorAlertStatus } from '@/lib/api';
+import {
+  mapAlertRecordToViewModel,
+  mapCallDetailToViewModel,
+  type SupervisorAlertViewModel,
+  type SupervisorCallViewModel,
+} from '@/lib/supervisor-alerts';
 import { CallDetailDrawer } from '@/components/CallDetailDrawer';
 import { toast } from '@/hooks/use-toast';
 import { AlertTable } from './components/AlertTable';
 import { AlertDetail } from './components/AlertDetail';
 
 export default function AlertsCenter() {
-  const { alerts, setAlerts, updateAlert } = useAppStore();
+  const queryClient = useQueryClient();
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [severityFilter, setSeverityFilter] = useState<string>('all');
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
-  const [detailAlert, setDetailAlert] = useState<(typeof alerts)[0] | null>(null);
+  const [detailAlert, setDetailAlert] = useState<SupervisorAlertViewModel | null>(null);
   const [callDrawerOpen, setCallDrawerOpen] = useState(false);
-  const [selectedCall, setSelectedCall] = useState<Call | null>(null);
+  const [selectedCall, setSelectedCall] = useState<SupervisorCallViewModel | null>(null);
 
-  useEffect(() => {
-    if (alerts.length === 0) {
-      setAlerts(mockData.alerts);
-    }
-  }, [alerts.length, setAlerts]);
+  const {
+    data: alertsResponse,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['alerts', 'list', statusFilter, severityFilter],
+    queryFn: () =>
+      alertsApi.listAlerts({
+        status:
+          statusFilter === 'all'
+            ? undefined
+            : (statusFilter as SupervisorAlertStatus),
+        severity:
+          severityFilter === 'all'
+            ? undefined
+            : (severityFilter as SupervisorAlertSeverity),
+        page: 1,
+        per_page: 100,
+    }),
+    staleTime: 30 * 1000,
+    refetchInterval: 10 * 1000,
+    retry: 1,
+  });
 
-  const filteredAlerts = useMemo(
+  const { data: openAlertsResponse } = useQuery({
+    queryKey: ['alerts', 'open-count'],
+    queryFn: () => alertsApi.listAlerts({ status: 'open', page: 1, per_page: 1 }),
+    staleTime: 30 * 1000,
+    refetchInterval: 10 * 1000,
+    retry: 1,
+  });
+
+  const alerts = useMemo(
+    () => (alertsResponse?.alerts ?? []).map(mapAlertRecordToViewModel),
+    [alertsResponse]
+  );
+
+  const callIds = useMemo(
     () =>
-      alerts.filter((alert) => {
-        if (statusFilter !== 'all' && alert.status !== statusFilter) return false;
-        if (severityFilter !== 'all' && alert.severity !== severityFilter) return false;
-        return true;
-      }),
-    [alerts, statusFilter, severityFilter]
-  );
-
-  const callsById = useMemo(
-    () => Object.fromEntries(mockData.calls.map((c) => [c.id, c])),
-    []
-  );
-
-  const openAlertsCount = useMemo(
-    () => alerts.filter((a) => a.status === 'open').length,
+      Array.from(
+        new Set(
+          alerts
+            .map((alert) => alert.callId)
+            .filter((callId): callId is string => Boolean(callId))
+        )
+      ),
     [alerts]
   );
 
+  const callQueries = useQueries({
+    queries: callIds.map((callId) => ({
+      queryKey: ['calls', 'detail', callId],
+      queryFn: () => callsApi.getCallById(callId),
+      staleTime: 30 * 1000,
+      retry: 1,
+    })),
+  });
+
+  const callsById = useMemo(
+    () =>
+      Object.fromEntries(
+        callQueries
+          .filter((query) => query.data)
+          .map((query) => {
+            const call = mapCallDetailToViewModel(query.data!);
+            return [call.id, call];
+          })
+      ),
+    [callQueries]
+  );
+
+  const updateAlertMutation = useMutation({
+    mutationFn: ({ alertId, patch }: { alertId: string; patch: { status?: 'open' | 'closed'; is_read?: boolean } }) =>
+      alertsApi.updateAlert(alertId, patch),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['alerts'] });
+    },
+  });
+
+  const openAlertsCount = openAlertsResponse?.total ?? 0;
+
   const handleSelectAll = (checked: boolean) => {
     if (checked) {
-      setSelectedIds(filteredAlerts.map((a) => a.id));
+      setSelectedIds(alerts.map((alert) => alert.id));
     } else {
       setSelectedIds([]);
     }
@@ -54,40 +119,47 @@ export default function AlertsCenter() {
     if (checked) {
       setSelectedIds((prev) => [...prev, id]);
     } else {
-      setSelectedIds((prev) => prev.filter((i) => i !== id));
+      setSelectedIds((prev) => prev.filter((item) => item !== id));
     }
   };
 
-  const handleCloseSelected = () => {
-    selectedIds.forEach((id) => {
-      updateAlert(id, { status: 'closed' });
-    });
+  const handleCloseSelected = async () => {
+    await Promise.all(
+      selectedIds.map((id) =>
+        updateAlertMutation.mutateAsync({ alertId: id, patch: { status: 'closed' } })
+      )
+    );
+
     toast({
       title: 'Alerts Closed',
       description: `${selectedIds.length} alert(s) have been closed.`,
     });
     setSelectedIds([]);
+    if (detailAlert && selectedIds.includes(detailAlert.id)) {
+      setDetailAlert(null);
+    }
   };
 
-  const handleCloseAlert = (id: string) => {
-    updateAlert(id, { status: 'closed' });
+  const handleCloseAlert = async (id: string) => {
+    await updateAlertMutation.mutateAsync({ alertId: id, patch: { status: 'closed' } });
     toast({
       title: 'Alert Closed',
       description: 'The alert has been marked as closed.',
     });
-    setDetailAlert(null);
+    setDetailAlert((prev) => (prev && prev.id === id ? { ...prev, status: 'closed' } : prev));
   };
 
-  const handleReopenAlert = (id: string) => {
-    updateAlert(id, { status: 'open' });
+  const handleReopenAlert = async (id: string) => {
+    await updateAlertMutation.mutateAsync({ alertId: id, patch: { status: 'open' } });
     toast({
       title: 'Alert Reopened',
       description: 'The alert has been reopened.',
     });
+    setDetailAlert((prev) => (prev && prev.id === id ? { ...prev, status: 'open' } : prev));
   };
 
   const openCallDetail = (callId: string) => {
-    const call = mockData.calls.find((c) => c.id === callId);
+    const call = callsById[callId];
     if (call) {
       setSelectedCall(call);
       setCallDrawerOpen(true);
@@ -105,12 +177,18 @@ export default function AlertsCenter() {
     }
   };
 
-  const detailCall = detailAlert ? callsById[detailAlert.callId] : undefined;
+  const detailCall = detailAlert?.callId ? callsById[detailAlert.callId] : undefined;
 
   return (
     <div className="container mx-auto px-6 py-8">
+      {isError && (
+        <div className="mb-4 rounded-lg border border-destructive/50 bg-destructive/5 p-4 text-sm text-destructive">
+          Failed to load alerts.
+        </div>
+      )}
+
       <AlertTable
-        alerts={filteredAlerts}
+        alerts={alerts}
         callsById={callsById}
         statusFilter={statusFilter}
         severityFilter={severityFilter}
@@ -122,17 +200,21 @@ export default function AlertsCenter() {
         onSelectRow={handleSelect}
         onOpenDetail={setDetailAlert}
         onOpenCall={openCallDetail}
-        onCloseSelected={handleCloseSelected}
+        onCloseSelected={() => void handleCloseSelected()}
         severityClassName={severityColor}
       />
+
+      {isLoading && (
+        <div className="mt-4 text-sm text-muted-foreground">Loading alerts...</div>
+      )}
 
       <AlertDetail
         alert={detailAlert}
         call={detailCall}
         onClose={() => setDetailAlert(null)}
         onOpenCall={openCallDetail}
-        onCloseAlert={handleCloseAlert}
-        onReopenAlert={handleReopenAlert}
+        onCloseAlert={(id) => void handleCloseAlert(id)}
+        onReopenAlert={(id) => void handleReopenAlert(id)}
         severityClassName={severityColor}
       />
 

--- a/frontend/src/pages/supervisor/Alerts.tsx
+++ b/frontend/src/pages/supervisor/Alerts.tsx
@@ -97,11 +97,49 @@ export default function AlertsCenter() {
     [callQueries]
   );
 
+  const {
+    data: relatedCallsResponse,
+    isLoading: isLoadingRelatedCalls,
+  } = useQuery({
+    queryKey: ['alerts', 'related-calls', detailAlert?.id],
+    queryFn: () => alertsApi.listAlertCalls(detailAlert!.id),
+    enabled: Boolean(detailAlert),
+    staleTime: 30 * 1000,
+    retry: 1,
+  });
+
+  const relatedCalls = useMemo(
+    () => (relatedCallsResponse?.calls ?? []).map(mapCallDetailToViewModel),
+    [relatedCallsResponse]
+  );
+
+  const relatedCallsById = useMemo(
+    () => Object.fromEntries(relatedCalls.map((call) => [call.id, call])),
+    [relatedCalls]
+  );
+
   const updateAlertMutation = useMutation({
     mutationFn: ({ alertId, patch }: { alertId: string; patch: { status?: 'open' | 'closed'; is_read?: boolean } }) =>
       alertsApi.updateAlert(alertId, patch),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['alerts'] });
+    },
+  });
+
+  const createManualAlertMutation = useMutation({
+    mutationFn: (callId: string) => alertsApi.createManualAlert({ call_id: callId }),
+    onSuccess: (createdAlert, callId) => {
+      void queryClient.invalidateQueries({ queryKey: ['alerts'] });
+      void queryClient.invalidateQueries({ queryKey: ['calls', 'detail', callId] });
+      setSelectedCall((prev) =>
+        prev && prev.id === callId
+          ? { ...prev, hasOpenAlert: true, openAlertId: createdAlert.id }
+          : prev
+      );
+      toast({
+        title: 'Alert Created',
+        description: 'The call has been flagged for manual review.',
+      });
     },
   });
 
@@ -159,7 +197,7 @@ export default function AlertsCenter() {
   };
 
   const openCallDetail = (callId: string) => {
-    const call = callsById[callId];
+    const call = relatedCallsById[callId] ?? callsById[callId];
     if (call) {
       setSelectedCall(call);
       setCallDrawerOpen(true);
@@ -176,8 +214,6 @@ export default function AlertsCenter() {
         return 'bg-muted text-muted-foreground';
     }
   };
-
-  const detailCall = detailAlert?.callId ? callsById[detailAlert.callId] : undefined;
 
   return (
     <div className="container mx-auto px-6 py-8">
@@ -210,7 +246,8 @@ export default function AlertsCenter() {
 
       <AlertDetail
         alert={detailAlert}
-        call={detailCall}
+        relatedCalls={relatedCalls}
+        isLoadingRelatedCalls={isLoadingRelatedCalls}
         onClose={() => setDetailAlert(null)}
         onOpenCall={openCallDetail}
         onCloseAlert={(id) => void handleCloseAlert(id)}
@@ -222,6 +259,9 @@ export default function AlertsCenter() {
         call={selectedCall}
         open={callDrawerOpen}
         onOpenChange={setCallDrawerOpen}
+        canCreateAlert
+        isCreatingAlert={createManualAlertMutation.isPending}
+        onCreateAlert={(callId) => createManualAlertMutation.mutateAsync(callId)}
       />
     </div>
   );

--- a/frontend/src/pages/supervisor/Overview.tsx
+++ b/frontend/src/pages/supervisor/Overview.tsx
@@ -1,9 +1,8 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
-import { mockData } from '@/lib/mock-data';
-import { dashboardApi } from '@/lib/api';
-import { useAppStore } from '@/stores/app-store';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { alertsApi, callsApi, dashboardApi } from '@/lib/api';
+import { mapAlertRecordToViewModel, mapCallDetailToViewModel } from '@/lib/supervisor-alerts';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Select,
@@ -71,7 +70,6 @@ function ErrorState({ error, onRetry }: ErrorStateProps) {
 
 export default function SupervisorOverview() {
   const navigate = useNavigate();
-  const { alerts, setAlerts } = useAppStore();
   const [dateRange, setDateRange] = useState<DateRangeOption>('14');
 
   // Fetch dashboard data from API
@@ -88,29 +86,82 @@ export default function SupervisorOverview() {
     retry: 1,
   });
 
-  // Initialize alerts from mock data if empty (alerts are managed separately)
-  useEffect(() => {
-    if (alerts.length === 0) {
-      setAlerts(mockData.alerts);
-    }
-  }, [alerts.length, setAlerts]);
+  const {
+    data: recentAlertsResponse,
+    isLoading: isRecentAlertsLoading,
+    isError: isRecentAlertsError,
+    error: recentAlertsError,
+    refetch: refetchRecentAlerts,
+  } = useQuery({
+    queryKey: ['alerts', 'recent-open'],
+    queryFn: () => alertsApi.listAlerts({ status: 'open', page: 1, per_page: 5 }),
+    staleTime: 30 * 1000,
+    refetchInterval: 10 * 1000,
+    retry: 1,
+  });
 
-  // Computed values from alerts (not from API)
-  const openAlerts = useMemo(
-    () => alerts.filter((a) => a.status === 'open').length,
-    [alerts]
-  );
+  const {
+    data: totalAlertsResponse,
+    isLoading: isTotalAlertsLoading,
+    isError: isTotalAlertsError,
+    error: totalAlertsError,
+    refetch: refetchTotalAlerts,
+  } = useQuery({
+    queryKey: ['alerts', 'total-count'],
+    queryFn: () => alertsApi.listAlerts({ page: 1, per_page: 1 }),
+    staleTime: 30 * 1000,
+    refetchInterval: 10 * 1000,
+    retry: 1,
+  });
 
   const recentAlerts = useMemo(
-    () => alerts.filter((a) => a.status === 'open').slice(0, 5),
-    [alerts]
+    () => (recentAlertsResponse?.alerts ?? []).map(mapAlertRecordToViewModel),
+    [recentAlertsResponse]
   );
 
-  // Call lookup for alert details (still using mock for now)
-  const callsById = useMemo(
-    () => Object.fromEntries(mockData.calls.map((c) => [c.id, c])),
-    []
+  const callIds = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          recentAlerts
+            .map((alert) => alert.callId)
+            .filter((callId): callId is string => Boolean(callId))
+        )
+      ),
+    [recentAlerts]
   );
+
+  const callQueries = useQueries({
+    queries: callIds.map((callId) => ({
+      queryKey: ['calls', 'detail', callId],
+      queryFn: () => callsApi.getCallById(callId),
+      staleTime: 30 * 1000,
+      retry: 1,
+    })),
+  });
+
+  const callsById = useMemo(
+    () =>
+      Object.fromEntries(
+        callQueries
+          .filter((query) => query.data)
+          .map((query) => {
+            const call = mapCallDetailToViewModel(query.data!);
+            return [call.id, call];
+          })
+      ),
+    [callQueries]
+  );
+
+  const alertsError = (recentAlertsError || totalAlertsError) as Error | null;
+  const alertsRefetch = () => {
+    void refetchRecentAlerts();
+    void refetchTotalAlerts();
+  };
+  const openAlerts = recentAlertsResponse?.total ?? 0;
+  const totalAlerts = totalAlertsResponse?.total ?? 0;
+  const alertsLoading = isRecentAlertsLoading || isTotalAlertsLoading;
+  const alertsFailed = isRecentAlertsError || isTotalAlertsError;
 
   return (
     <div className="container mx-auto px-6 py-8">
@@ -130,9 +181,17 @@ export default function SupervisorOverview() {
         </Select>
       </div>
 
-      {isError && <ErrorState error={error as Error} onRetry={() => refetch()} />}
+      {(isError || alertsFailed) && (
+        <ErrorState
+          error={(error as Error) || alertsError || new Error('Failed to load alert data')}
+          onRetry={() => {
+            void refetch();
+            alertsRefetch();
+          }}
+        />
+      )}
 
-      {isLoading ? (
+      {isLoading || alertsLoading ? (
         <OverviewSkeleton />
       ) : dashboardData ? (
         <>
@@ -143,7 +202,7 @@ export default function SupervisorOverview() {
             negativePercent={dashboardData.negativePercent}
             negativeCallCount={dashboardData.negativeCallCount}
             openAlerts={openAlerts}
-            totalAlerts={alerts.length}
+            totalAlerts={totalAlerts}
           />
 
           <Tabs defaultValue="trends" className="space-y-6">

--- a/frontend/src/pages/supervisor/Settings.tsx
+++ b/frontend/src/pages/supervisor/Settings.tsx
@@ -1,4 +1,10 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { alertsApi } from '@/lib/api';
+import {
+  deriveAlertSettingsViewModel,
+  normalizeKeywordInput,
+} from '@/lib/supervisor-alerts';
 import { useAppStore } from '@/stores/app-store';
 import { resetAndReseed } from '@/lib/seed';
 import { Card } from '@/components/ui/card';
@@ -29,13 +35,103 @@ import {
 } from 'lucide-react';
 
 export default function Settings() {
+  const queryClient = useQueryClient();
   const { settings, updateSettings, sentEmails } = useAppStore();
   const [newKeyword, setNewKeyword] = useState('');
   const [resetLoading, setResetLoading] = useState(false);
+  const [sentimentThreshold, setSentimentThreshold] = useState(-0.5);
 
-  const handleAddKeyword = () => {
-    if (!newKeyword.trim()) return;
-    if (settings.keywords.includes(newKeyword.trim().toLowerCase())) {
+  const { data: rulesResponse, isLoading: rulesLoading } = useQuery({
+    queryKey: ['alerts', 'rules'],
+    queryFn: () => alertsApi.listRules(),
+    staleTime: 30 * 1000,
+    retry: 1,
+  });
+
+  const settingsView = useMemo(
+    () => deriveAlertSettingsViewModel(rulesResponse?.rules ?? []),
+    [rulesResponse]
+  );
+
+  useEffect(() => {
+    const backendThreshold = settingsView.thresholdRule?.sentiment_below;
+    if (backendThreshold !== null && backendThreshold !== undefined) {
+      setSentimentThreshold(backendThreshold);
+    } else {
+      setSentimentThreshold(-0.5);
+    }
+  }, [settingsView.thresholdRule?.id, settingsView.thresholdRule?.sentiment_below]);
+
+  const saveThresholdMutation = useMutation({
+    mutationFn: async (value: number) => {
+      const canonicalRule = settingsView.thresholdRule;
+      if (canonicalRule) {
+        await alertsApi.updateRule(canonicalRule.id, {
+          severity: 'high',
+          is_active: true,
+          sentiment_below: value,
+        });
+      } else {
+        await alertsApi.createRule({
+          type: 'sentiment_threshold',
+          severity: 'high',
+          sentiment_below: value,
+          is_active: true,
+        });
+      }
+
+      await Promise.all(
+        settingsView.duplicateThresholdRules.map((rule) =>
+          alertsApi.updateRule(rule.id, { is_active: false })
+        )
+      );
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['alerts', 'rules'] });
+      toast({
+        title: 'Threshold Updated',
+        description: 'The supervisor sentiment alert threshold has been saved.',
+      });
+    },
+  });
+
+  const createKeywordMutation = useMutation({
+    mutationFn: (keyword: string) =>
+      alertsApi.createRule({
+        type: 'keyword_match',
+        severity: 'high',
+        keyword,
+        is_active: true,
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['alerts', 'rules'] });
+    },
+  });
+
+  const deactivateKeywordMutation = useMutation({
+    mutationFn: async (keyword: string) => {
+      const matchingRules = settingsView.keywordRules.filter((rule) => rule.keyword === keyword);
+      await Promise.all(
+        matchingRules.map((rule) =>
+          alertsApi.updateRule(rule.id, { is_active: false })
+        )
+      );
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['alerts', 'rules'] });
+    },
+  });
+
+  const handleThresholdCommit = async (value: number) => {
+    setSentimentThreshold(value);
+    await saveThresholdMutation.mutateAsync(value);
+  };
+
+  const handleAddKeyword = async () => {
+    const normalizedKeyword = normalizeKeywordInput(newKeyword);
+    if (!normalizedKeyword) return;
+
+    if (settingsView.keywords.includes(normalizedKeyword)) {
       toast({
         title: 'Keyword Exists',
         description: 'This keyword is already in the list.',
@@ -43,20 +139,17 @@ export default function Settings() {
       });
       return;
     }
-    updateSettings({
-      keywords: [...settings.keywords, newKeyword.trim().toLowerCase()],
-    });
+
+    await createKeywordMutation.mutateAsync(normalizedKeyword);
     setNewKeyword('');
     toast({
       title: 'Keyword Added',
-      description: `"${newKeyword}" has been added to alert keywords.`,
+      description: `"${normalizedKeyword}" has been added to alert keywords.`,
     });
   };
 
-  const handleRemoveKeyword = (keyword: string) => {
-    updateSettings({
-      keywords: settings.keywords.filter((k) => k !== keyword),
-    });
+  const handleRemoveKeyword = async (keyword: string) => {
+    await deactivateKeywordMutation.mutateAsync(keyword);
     toast({
       title: 'Keyword Removed',
       description: `"${keyword}" has been removed from alert keywords.`,
@@ -65,18 +158,13 @@ export default function Settings() {
 
   const handleResetDemo = async () => {
     setResetLoading(true);
-    
-    // Small delay for UX
     await new Promise((r) => setTimeout(r, 500));
-    
-    // Reset and reseed data
     resetAndReseed();
-    
     setResetLoading(false);
-    
+
     toast({
       title: 'Demo Reset Complete',
-      description: 'All data has been cleared and re-seeded with fresh mock data.',
+      description: 'Local demo data has been cleared and refreshed. Backend alert rules were not changed.',
     });
   };
 
@@ -89,7 +177,6 @@ export default function Settings() {
         </h2>
 
         <div className="space-y-6">
-          {/* Alert Thresholds */}
           <Card className="p-6">
             <h3 className="font-semibold flex items-center gap-2 mb-4">
               <Bell className="h-4 w-4" />
@@ -98,19 +185,18 @@ export default function Settings() {
             <div className="space-y-4">
               <div>
                 <Label className="mb-2 block">
-                  Sentiment Threshold: {settings.sentimentThreshold.toFixed(1)}
+                  Sentiment Threshold: {sentimentThreshold.toFixed(1)}
                 </Label>
                 <p className="text-sm text-muted-foreground mb-3">
                   Calls with sentiment below this value will trigger alerts.
                 </p>
                 <Slider
                   min={-1}
-                  max={0}
+                  max={1}
                   step={0.1}
-                  value={[settings.sentimentThreshold]}
-                  onValueChange={(value) =>
-                    updateSettings({ sentimentThreshold: value[0] })
-                  }
+                  value={[sentimentThreshold]}
+                  onValueChange={(value) => setSentimentThreshold(value[0])}
+                  onValueCommit={(value) => void handleThresholdCommit(value[0])}
                 />
               </div>
               <Separator />
@@ -120,7 +206,7 @@ export default function Settings() {
                   Calls containing these keywords will trigger alerts.
                 </p>
                 <div className="flex flex-wrap gap-2 mb-3">
-                  {settings.keywords.map((keyword) => (
+                  {settingsView.keywords.map((keyword) => (
                     <Badge
                       key={keyword}
                       variant="secondary"
@@ -128,7 +214,7 @@ export default function Settings() {
                     >
                       {keyword}
                       <button
-                        onClick={() => handleRemoveKeyword(keyword)}
+                        onClick={() => void handleRemoveKeyword(keyword)}
                         className="ml-1 hover:text-destructive"
                       >
                         <X className="h-3 w-3" />
@@ -141,17 +227,19 @@ export default function Settings() {
                     placeholder="Add keyword..."
                     value={newKeyword}
                     onChange={(e) => setNewKeyword(e.target.value)}
-                    onKeyDown={(e) => e.key === 'Enter' && handleAddKeyword()}
+                    onKeyDown={(e) => e.key === 'Enter' && void handleAddKeyword()}
                   />
-                  <Button onClick={handleAddKeyword} size="icon">
+                  <Button onClick={() => void handleAddKeyword()} size="icon">
                     <Plus className="h-4 w-4" />
                   </Button>
                 </div>
+                {rulesLoading && (
+                  <p className="text-xs text-muted-foreground mt-2">Loading alert rules...</p>
+                )}
               </div>
             </div>
           </Card>
 
-          {/* Data Retention */}
           <Card className="p-6">
             <h3 className="font-semibold flex items-center gap-2 mb-4">
               <Database className="h-4 w-4" />
@@ -165,7 +253,7 @@ export default function Settings() {
               <Select
                 value={settings.dataRetentionDays.toString()}
                 onValueChange={(value) =>
-                  updateSettings({ dataRetentionDays: parseInt(value) })
+                  updateSettings({ dataRetentionDays: parseInt(value, 10) })
                 }
               >
                 <SelectTrigger className="w-48">
@@ -180,7 +268,6 @@ export default function Settings() {
             </div>
           </Card>
 
-          {/* Email Outbox */}
           <Card className="p-6">
             <h3 className="font-semibold flex items-center gap-2 mb-4">
               <Mail className="h-4 w-4" />
@@ -212,15 +299,14 @@ export default function Settings() {
             )}
           </Card>
 
-          {/* Reset Demo */}
           <Card className="p-6 border-destructive/50">
             <h3 className="font-semibold flex items-center gap-2 mb-4 text-destructive">
               <Trash2 className="h-4 w-4" />
               Reset Demo Data
             </h3>
             <p className="text-sm text-muted-foreground mb-4">
-              Clear all persisted state (alerts, briefs, notes, settings) and
-              re-seed with fresh mock data. This action cannot be undone.
+              Clear local persisted state used for demo-only features such as briefs, notes,
+              notifications, and local preferences. Backend alert rules are not reset here.
             </p>
             <Button
               variant="destructive"

--- a/frontend/src/pages/supervisor/components/AlertDetail.tsx
+++ b/frontend/src/pages/supervisor/components/AlertDetail.tsx
@@ -12,7 +12,8 @@ import type { SupervisorAlertViewModel, SupervisorCallViewModel } from '@/lib/su
 
 export interface AlertDetailProps {
   alert: SupervisorAlertViewModel | null;
-  call: SupervisorCallViewModel | undefined;
+  relatedCalls: SupervisorCallViewModel[];
+  isLoadingRelatedCalls?: boolean;
   onClose: () => void;
   onOpenCall: (callId: string) => void;
   onCloseAlert: (id: string) => void;
@@ -22,13 +23,18 @@ export interface AlertDetailProps {
 
 export function AlertDetail({
   alert,
-  call,
+  relatedCalls,
+  isLoadingRelatedCalls = false,
   onClose,
   onOpenCall,
   onCloseAlert,
   onReopenAlert,
   severityClassName,
 }: AlertDetailProps) {
+  const primaryCall = relatedCalls[0];
+  const isRecurringAlert =
+    alert?.type === 'recurring_topic' || alert?.type === 'recurring_keyword';
+
   return (
     <Sheet open={!!alert} onOpenChange={(open) => !open && onClose()}>
       <SheetContent>
@@ -54,34 +60,70 @@ export function AlertDetail({
               <p className="text-sm text-muted-foreground">{alert.issue}</p>
             </div>
 
-            {call && (
+            {!isRecurringAlert && primaryCall && (
               <div className="p-4 bg-muted/50 rounded-lg space-y-3">
                 <h5 className="text-sm font-medium">Call Information</h5>
                 <div className="grid grid-cols-2 gap-3 text-sm">
                   <div className="flex items-center gap-2">
                     <User className="h-4 w-4 text-muted-foreground" />
-                    {call.agentName}
+                    {primaryCall.agentName}
                   </div>
                   <div className="flex items-center gap-2">
                     <Clock className="h-4 w-4 text-muted-foreground" />
-                    {Math.floor(call.durationSec / 60)}m {call.durationSec % 60}s
+                    {Math.floor(primaryCall.durationSec / 60)}m {primaryCall.durationSec % 60}s
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
                   <span className="text-muted-foreground">Sentiment:</span>
-                  <SentimentBadge sentiment={call.sentimentLabel} />
+                  <SentimentBadge sentiment={primaryCall.sentimentLabel} />
                 </div>
                 <Button
                   variant="outline"
                   size="sm"
                   className="w-full"
                   onClick={() => {
-                    onOpenCall(call.id);
+                    onOpenCall(primaryCall.id);
                     onClose();
                   }}
                 >
                   View Full Call Details
                 </Button>
+              </div>
+            )}
+
+            {isRecurringAlert && (
+              <div className="p-4 bg-muted/50 rounded-lg space-y-3">
+                <h5 className="text-sm font-medium">
+                  Affected Calls
+                  {alert?.matchedCount ? ` (${alert.matchedCount})` : ''}
+                </h5>
+                {isLoadingRelatedCalls ? (
+                  <p className="text-sm text-muted-foreground">Loading related calls...</p>
+                ) : relatedCalls.length > 0 ? (
+                  <div className="space-y-2">
+                    {relatedCalls.map((call) => (
+                      <Button
+                        key={call.id}
+                        variant="outline"
+                        size="sm"
+                        className="w-full justify-between"
+                        onClick={() => {
+                          onOpenCall(call.id);
+                          onClose();
+                        }}
+                      >
+                        <span className="truncate text-left">
+                          {call.agentName} · {new Date(call.startedAt).toLocaleDateString()}
+                        </span>
+                        <SentimentBadge sentiment={call.sentimentLabel} />
+                      </Button>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    No contributing calls were found for this recurring alert.
+                  </p>
+                )}
               </div>
             )}
 

--- a/frontend/src/pages/supervisor/components/AlertDetail.tsx
+++ b/frontend/src/pages/supervisor/components/AlertDetail.tsx
@@ -8,11 +8,11 @@ import {
 } from '@/components/ui/sheet';
 import { SentimentBadge } from '@/components/SentimentBadge';
 import { AlertTriangle, CheckCircle, User, Clock } from 'lucide-react';
-import type { Alert, Call } from '@/lib/mock-data';
+import type { SupervisorAlertViewModel, SupervisorCallViewModel } from '@/lib/supervisor-alerts';
 
 export interface AlertDetailProps {
-  alert: Alert | null;
-  call: Call | undefined;
+  alert: SupervisorAlertViewModel | null;
+  call: SupervisorCallViewModel | undefined;
   onClose: () => void;
   onOpenCall: (callId: string) => void;
   onCloseAlert: (id: string) => void;

--- a/frontend/src/pages/supervisor/components/AlertTable.tsx
+++ b/frontend/src/pages/supervisor/components/AlertTable.tsx
@@ -10,11 +10,11 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Eye } from 'lucide-react';
-import type { Alert, Call } from '@/lib/mock-data';
+import type { SupervisorAlertViewModel, SupervisorCallViewModel } from '@/lib/supervisor-alerts';
 
 export interface AlertTableProps {
-  alerts: Alert[];
-  callsById: Record<string, Call>;
+  alerts: SupervisorAlertViewModel[];
+  callsById: Record<string, SupervisorCallViewModel>;
   statusFilter: string;
   severityFilter: string;
   selectedIds: string[];
@@ -23,7 +23,7 @@ export interface AlertTableProps {
   onSeverityFilterChange: (value: string) => void;
   onSelectAll: (checked: boolean) => void;
   onSelectRow: (id: string, checked: boolean) => void;
-  onOpenDetail: (alert: Alert) => void;
+  onOpenDetail: (alert: SupervisorAlertViewModel) => void;
   onOpenCall: (callId: string) => void;
   onCloseSelected: () => void;
   severityClassName: (severity: string) => string;
@@ -106,7 +106,7 @@ export function AlertTable({
             </thead>
             <tbody>
               {alerts.map((alert) => {
-                const call = callsById[alert.callId];
+                const call = alert.callId ? callsById[alert.callId] : undefined;
                 return (
                   <tr
                     key={alert.id}
@@ -147,7 +147,8 @@ export function AlertTable({
                       <Button
                         variant="ghost"
                         size="sm"
-                        onClick={() => onOpenCall(alert.callId)}
+                        onClick={() => alert.callId && onOpenCall(alert.callId)}
+                        disabled={!alert.callId}
                       >
                         <Eye className="h-4 w-4" />
                       </Button>

--- a/frontend/src/pages/supervisor/components/AlertTable.tsx
+++ b/frontend/src/pages/supervisor/components/AlertTable.tsx
@@ -131,7 +131,14 @@ export function AlertTable({
                       <span className="text-sm text-muted-foreground">{alert.issue}</span>
                     </td>
                     <td className="p-4">
-                      <span className="text-sm">{call?.agentName || 'Unknown'}</span>
+                      <span className="text-sm">
+                        {call?.agentName ||
+                          (alert.type === 'recurring_topic' || alert.type === 'recurring_keyword'
+                            ? `${alert.matchedCount ?? 0} affected calls`
+                            : alert.type === 'manual'
+                              ? 'Manual review'
+                              : 'Unknown')}
+                      </span>
                     </td>
                     <td className="p-4">
                       <span className="text-sm text-muted-foreground">
@@ -147,8 +154,13 @@ export function AlertTable({
                       <Button
                         variant="ghost"
                         size="sm"
-                        onClick={() => alert.callId && onOpenCall(alert.callId)}
-                        disabled={!alert.callId}
+                        onClick={() => {
+                          if (alert.callId) {
+                            onOpenCall(alert.callId);
+                            return;
+                          }
+                          onOpenDetail(alert);
+                        }}
                       >
                         <Eye className="h-4 w-4" />
                       </Button>

--- a/frontend/src/pages/supervisor/components/RecentAlerts.tsx
+++ b/frontend/src/pages/supervisor/components/RecentAlerts.tsx
@@ -3,13 +3,13 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { SentimentBadge } from '@/components/SentimentBadge';
 import { AlertTriangle, ArrowUpRight, Users, Clock } from 'lucide-react';
-import type { Alert, Call } from '@/lib/mock-data';
+import type { SupervisorAlertViewModel, SupervisorCallViewModel } from '@/lib/supervisor-alerts';
 
 export interface RecentAlertsProps {
-  alerts: Alert[];
-  callsById: Record<string, Call>;
+  alerts: SupervisorAlertViewModel[];
+  callsById: Record<string, SupervisorCallViewModel>;
   onViewAll: () => void;
-  onAlertClick: (alert: Alert) => void;
+  onAlertClick: (alert: SupervisorAlertViewModel) => void;
 }
 
 export function RecentAlerts({ alerts, callsById, onViewAll, onAlertClick }: RecentAlertsProps) {
@@ -30,7 +30,7 @@ export function RecentAlerts({ alerts, callsById, onViewAll, onAlertClick }: Rec
           <p className="text-muted-foreground text-center py-8">No open alerts</p>
         ) : (
           alerts.map((alert) => {
-            const call = callsById[alert.callId];
+            const call = alert.callId ? callsById[alert.callId] : undefined;
             return (
               <div
                 key={alert.id}

--- a/frontend/src/pages/supervisor/components/__tests__/AlertDetail.test.tsx
+++ b/frontend/src/pages/supervisor/components/__tests__/AlertDetail.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AlertDetail } from '../AlertDetail';
+
+describe('AlertDetail', () => {
+  it('renders affected calls for recurring alerts', () => {
+    render(
+      <AlertDetail
+        alert={{
+          id: 'alert-1',
+          type: 'recurring_keyword',
+          callId: null,
+          createdAt: '2026-04-02T12:00:00Z',
+          ruleId: 'rule-1',
+          ruleLabel: 'Recurring keyword detected',
+          severity: 'high',
+          status: 'open',
+          issue: 'Keyword "refund" appeared across multiple calls.',
+          matchedValue: 'refund',
+          matchedCount: 2,
+          windowDays: 7,
+        }}
+        relatedCalls={[
+          {
+            id: 'call-1',
+            agentId: 'agent-1',
+            agentName: 'Ada Lovelace',
+            startedAt: '2026-04-02T12:00:00Z',
+            durationSec: 240,
+            sentimentScore: -0.3,
+            sentimentLabel: 'negative',
+            topics: ['refund'],
+            resolved: false,
+            csat: null,
+            customerName: 'Customer',
+            hasOpenAlert: false,
+            openAlertId: null,
+          },
+          {
+            id: 'call-2',
+            agentId: 'agent-2',
+            agentName: 'Grace Hopper',
+            startedAt: '2026-04-01T12:00:00Z',
+            durationSec: 180,
+            sentimentScore: -0.2,
+            sentimentLabel: 'negative',
+            topics: ['refund'],
+            resolved: true,
+            csat: null,
+            customerName: 'Customer',
+            hasOpenAlert: false,
+            openAlertId: null,
+          },
+        ]}
+        onClose={vi.fn()}
+        onOpenCall={vi.fn()}
+        onCloseAlert={vi.fn()}
+        onReopenAlert={vi.fn()}
+        severityClassName={() => 'severity'}
+      />
+    );
+
+    expect(screen.getByText('Affected Calls (2)')).toBeInTheDocument();
+    expect(screen.getByText(/Ada Lovelace/)).toBeInTheDocument();
+    expect(screen.getByText(/Grace Hopper/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/stores/app-store.ts
+++ b/frontend/src/stores/app-store.ts
@@ -1,6 +1,5 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import type { Alert, Call } from '@/lib/mock-data';
 
 interface SentEmail {
   id: string;
@@ -66,17 +65,10 @@ interface AgentCall {
 }
 
 interface Settings {
-  sentimentThreshold: number;
-  keywords: string[];
   dataRetentionDays: number;
 }
 
 interface AppState {
-  // Alerts
-  alerts: Alert[];
-  setAlerts: (alerts: Alert[]) => void;
-  updateAlert: (alertId: string, patch: Partial<Alert>) => void;
-  
   // Exemplars
   exemplarCallIds: string[];
   toggleExemplar: (callId: string) => void;
@@ -119,23 +111,12 @@ interface AppState {
 }
 
 const defaultSettings: Settings = {
-  sentimentThreshold: -0.5,
-  keywords: ['refund', 'cancel', 'supervisor', 'complaint', 'chargeback'],
   dataRetentionDays: 30,
 };
 
 export const useAppStore = create<AppState>()(
   persist(
-    (set, get) => ({
-      alerts: [],
-      setAlerts: (alerts) => set({ alerts }),
-      updateAlert: (alertId, patch) =>
-        set((state) => ({
-          alerts: state.alerts.map((a) =>
-            a.id === alertId ? { ...a, ...patch } : a
-          ),
-        })),
-
+    (set) => ({
       exemplarCallIds: [],
       toggleExemplar: (callId) =>
         set((state) => ({
@@ -234,7 +215,6 @@ export const useAppStore = create<AppState>()(
 
       resetAll: () =>
         set({
-          alerts: [],
           exemplarCallIds: [],
           bookmarkedExemplars: [],
           callNotes: [],

--- a/migrations/4-expand-alerting-engine.sql
+++ b/migrations/4-expand-alerting-engine.sql
@@ -1,0 +1,98 @@
+-- ============================================================
+-- MIGRATION: Expand alerting engine for rule-based automation
+-- ============================================================
+
+-- ============================================================
+-- 1. EXTEND alert_type enum with new rule and alert values
+-- ============================================================
+
+DO $$
+BEGIN
+  ALTER TYPE alert_type ADD VALUE 'sentiment_threshold';
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER TYPE alert_type ADD VALUE 'keyword_match';
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER TYPE alert_type ADD VALUE 'recurring_topic';
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER TYPE alert_type ADD VALUE 'recurring_keyword';
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- ============================================================
+-- 2. EXPAND alert_configurations for backend-first rules engine
+-- ============================================================
+
+ALTER TABLE alert_configurations
+  ADD COLUMN IF NOT EXISTS severity alert_severity NOT NULL DEFAULT 'medium',
+  ADD COLUMN IF NOT EXISTS sentiment_below DECIMAL(4, 3),
+  ADD COLUMN IF NOT EXISTS keyword VARCHAR(100),
+  ADD COLUMN IF NOT EXISTS topic VARCHAR(100),
+  ADD COLUMN IF NOT EXISTS min_occurrences INTEGER NOT NULL DEFAULT 3,
+  ADD COLUMN IF NOT EXISTS window_days INTEGER NOT NULL DEFAULT 7;
+
+CREATE INDEX IF NOT EXISTS idx_alert_configurations_team_id
+  ON alert_configurations(team_id);
+
+CREATE INDEX IF NOT EXISTS idx_alert_configurations_supervisor_id
+  ON alert_configurations(supervisor_id);
+
+CREATE INDEX IF NOT EXISTS idx_alert_configurations_is_active
+  ON alert_configurations(is_active);
+
+-- ============================================================
+-- 3. EXPAND alerts table for recurring alerts and rule tracing
+-- ============================================================
+
+ALTER TABLE alerts
+  ALTER COLUMN call_id DROP NOT NULL;
+
+ALTER TABLE alerts
+  ADD COLUMN IF NOT EXISTS rule_id UUID REFERENCES alert_configurations(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS matched_value VARCHAR(100),
+  ADD COLUMN IF NOT EXISTS matched_count INTEGER,
+  ADD COLUMN IF NOT EXISTS window_days INTEGER;
+
+ALTER TABLE alerts
+  ADD COLUMN IF NOT EXISTS title VARCHAR(255),
+  ADD COLUMN IF NOT EXISTS description TEXT,
+  ADD COLUMN IF NOT EXISTS status alert_status NOT NULL DEFAULT 'open',
+  ADD COLUMN IF NOT EXISTS type alert_type NOT NULL DEFAULT 'sentiment_threshold';
+
+DO $$
+BEGIN
+  ALTER TABLE alerts DROP CONSTRAINT alerts_call_id_key;
+EXCEPTION
+  WHEN undefined_object THEN NULL;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_alerts_rule_call_unique
+  ON alerts(rule_id, call_id)
+  WHERE call_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_alerts_rule_id
+  ON alerts(rule_id);
+
+CREATE INDEX IF NOT EXISTS idx_alerts_matched_value
+  ON alerts(matched_value);
+
+CREATE INDEX IF NOT EXISTS idx_alerts_status
+  ON alerts(status);
+
+CREATE INDEX IF NOT EXISTS idx_alerts_type
+  ON alerts(type);

--- a/migrations/5-drop-legacy-alert-rule-columns.sql
+++ b/migrations/5-drop-legacy-alert-rule-columns.sql
@@ -1,0 +1,7 @@
+-- ============================================================
+-- MIGRATION: Drop legacy alert rule columns
+-- ============================================================
+
+ALTER TABLE alert_configurations
+  DROP COLUMN IF EXISTS sentiment_threshold,
+  DROP COLUMN IF EXISTS keyword_id;

--- a/migrations/Datatbase.SQL
+++ b/migrations/Datatbase.SQL
@@ -4,8 +4,14 @@
 
 CREATE TYPE user_role AS ENUM ('agent', 'supervisor');
 CREATE TYPE sentiment_label AS ENUM ('positive', 'neutral', 'negative');
-CREATE TYPE alert_type AS ENUM ('threshold', 'keyword');
+CREATE TYPE alert_type AS ENUM (
+  'sentiment_threshold',
+  'keyword_match',
+  'recurring_topic',
+  'recurring_keyword'
+);
 CREATE TYPE alert_severity AS ENUM ('low', 'medium', 'high');
+CREATE TYPE alert_status AS ENUM ('open', 'closed');
 CREATE TYPE notification_type AS ENUM ('alert', 'coaching_tip', 'exemplar_added');
 CREATE TYPE notification_reference_type AS ENUM ('call', 'alert', 'coaching_tip', 'exemplar_call');
 
@@ -126,8 +132,12 @@ CREATE TABLE alert_configurations (
   supervisor_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
   type alert_type NOT NULL,
-  sentiment_threshold DECIMAL(4, 3) CHECK (sentiment_threshold BETWEEN -1.0 AND 1.0),
-  keyword_id UUID REFERENCES keywords(id) ON DELETE SET NULL,
+  severity alert_severity NOT NULL DEFAULT 'medium',
+  sentiment_below DECIMAL(4, 3) CHECK (sentiment_below BETWEEN -1.0 AND 1.0),
+  keyword VARCHAR(100),
+  topic VARCHAR(100),
+  min_occurrences INTEGER NOT NULL DEFAULT 3,
+  window_days INTEGER NOT NULL DEFAULT 7,
   is_active BOOLEAN DEFAULT TRUE,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
@@ -139,11 +149,19 @@ CREATE TABLE alert_configurations (
 
 CREATE TABLE alerts (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  call_id UUID NOT NULL UNIQUE REFERENCES calls(id) ON DELETE CASCADE,
+  call_id UUID REFERENCES calls(id) ON DELETE CASCADE,
+  rule_id UUID REFERENCES alert_configurations(id) ON DELETE SET NULL,
   supervisor_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  type alert_type NOT NULL DEFAULT 'sentiment_threshold',
+  status alert_status NOT NULL DEFAULT 'open',
   severity alert_severity NOT NULL,
+  title VARCHAR(255),
+  description TEXT,
   is_read BOOLEAN DEFAULT FALSE,
+  matched_value VARCHAR(100),
+  matched_count INTEGER,
+  window_days INTEGER,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );

--- a/migrations/Datatbase.SQL
+++ b/migrations/Datatbase.SQL
@@ -4,14 +4,8 @@
 
 CREATE TYPE user_role AS ENUM ('agent', 'supervisor');
 CREATE TYPE sentiment_label AS ENUM ('positive', 'neutral', 'negative');
-CREATE TYPE alert_type AS ENUM (
-  'sentiment_threshold',
-  'keyword_match',
-  'recurring_topic',
-  'recurring_keyword'
-);
+CREATE TYPE alert_type AS ENUM ('threshold', 'keyword');
 CREATE TYPE alert_severity AS ENUM ('low', 'medium', 'high');
-CREATE TYPE alert_status AS ENUM ('open', 'closed');
 CREATE TYPE notification_type AS ENUM ('alert', 'coaching_tip', 'exemplar_added');
 CREATE TYPE notification_reference_type AS ENUM ('call', 'alert', 'coaching_tip', 'exemplar_call');
 
@@ -132,12 +126,8 @@ CREATE TABLE alert_configurations (
   supervisor_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
   type alert_type NOT NULL,
-  severity alert_severity NOT NULL DEFAULT 'medium',
-  sentiment_below DECIMAL(4, 3) CHECK (sentiment_below BETWEEN -1.0 AND 1.0),
-  keyword VARCHAR(100),
-  topic VARCHAR(100),
-  min_occurrences INTEGER NOT NULL DEFAULT 3,
-  window_days INTEGER NOT NULL DEFAULT 7,
+  sentiment_threshold DECIMAL(4, 3) CHECK (sentiment_threshold BETWEEN -1.0 AND 1.0),
+  keyword_id UUID REFERENCES keywords(id) ON DELETE SET NULL,
   is_active BOOLEAN DEFAULT TRUE,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
@@ -149,19 +139,11 @@ CREATE TABLE alert_configurations (
 
 CREATE TABLE alerts (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  call_id UUID REFERENCES calls(id) ON DELETE CASCADE,
-  rule_id UUID REFERENCES alert_configurations(id) ON DELETE SET NULL,
+  call_id UUID NOT NULL UNIQUE REFERENCES calls(id) ON DELETE CASCADE,
   supervisor_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
-  type alert_type NOT NULL DEFAULT 'sentiment_threshold',
-  status alert_status NOT NULL DEFAULT 'open',
   severity alert_severity NOT NULL,
-  title VARCHAR(255),
-  description TEXT,
   is_read BOOLEAN DEFAULT FALSE,
-  matched_value VARCHAR(100),
-  matched_count INTEGER,
-  window_days INTEGER,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );


### PR DESCRIPTION
## Summary
This PR adds end-to-end supervisor alerting across the backend and frontend. It introduces real alert rules and generated alerts on the backend, wires simulated agent calls into alert evaluation, and connects the supervisor Overview, Alerts Center, and Settings pages to live backend data instead of mock/local alert state. The goal is to make supervisor alerts a real workflow rather than a demo-only shell.

## Changes
- Added backend alert management endpoints for listing alerts, updating alert state, listing rules, creating rules, and updating rules.
- Added backend alert rule evaluation for simulated calls, including `sentiment_threshold`, `keyword_match`, `recurring_topic`, and `recurring_keyword`.
- Added schema migration for the expanded alerting model, including rule metadata, recurring alert fields, and rule linkage.
- Added backend `GET /api/calls/{call_id}` so supervisor alert views can fetch real call detail and transcript context.
- Wired supervisor Overview to load recent/open alerts from the backend.
- Wired Supervisor Alerts Center to load alerts from the backend and close/reopen them through backend mutations.
- Wired Supervisor Settings threshold and keyword management to backend alert rules.
- Removed supervisor alert seeding from mock/local demo state.
- Added a frontend adapter layer so existing alert UI components could stay visually unchanged while consuming backend data.
- Updated the call detail drawer to use real backend-backed call summaries/transcripts when available.
- Fixed the backend rule update path so threshold changes save correctly.
- Expanded the threshold slider to allow values from `-1.0` to `1.0`.
- Added periodic refetching on supervisor alert views so newly generated alerts appear without a hard reload.
- Removed leftover Zustand alert store plumbing and dead mock alert helpers that were no longer used by the supervisor flow.

## Test Plan
- Backend tests:
  - `backend/.venv/bin/python -m pytest backend/tests`
  - Result: `114 passed`
- Frontend tests:
  - `npm run test` in `frontend/`
  - Result: `21 passed`
- Frontend typecheck:
  - `npm run typecheck` in `frontend/`
  - Passed
- Backend lint:
  - `backend/.venv/bin/python -m ruff check backend`
  - Passed
- Frontend lint:
  - `npm run lint` in `frontend/`
  - No errors, only existing warnings in shared UI files
- Manual verification:
  - Applied the alerting migration to the shared Supabase project
  - Verified live supervisor rule creation and alert generation using supervisor and agent accounts on the same team
  - Confirmed alerts appear on the supervisor side after simulating calls
  - Confirmed threshold updates in Settings save correctly after fixing the backend patch path
  - Confirmed new alerts appear on supervisor pages after refetch/polling