### PR TITLE
Backend PR: Call Search API 

### DIFF
--- a/backend/api/routers/calls.py
+++ b/backend/api/routers/calls.py
@@ -17,8 +17,9 @@ from database.analysis import (
     create_analysis,
     get_analysis_by_call_id,
 )
-from database.calls import create_call
+from database.calls import create_call, search_calls
 from database.calls import get_call_by_id as fetch_call_by_id
+from database.constants import SortOrder, Tables
 from database.exceptions import DatabaseError, NotFoundError
 from database.sample_transcripts import get_random_sample_transcript
 from database.teams import get_team_by_id
@@ -80,10 +81,34 @@ class CallDetailResponse(BaseModel):
     sentiment_label: str | None = None
     is_resolved: bool | None = None
     topics: list[str]
+    keywords: list[str] = []
     summary: str | None = None
     transcript: list[CallDetailTranscriptTurn]
     has_open_alert: bool = False
     open_alert_id: str | None = None
+
+
+class CallSearchItem(BaseModel):
+    """A minimal call representation returned in search results."""
+
+    id: str
+    agent_id: str
+    agent_name: str
+    started_at: str | None = None
+    duration_seconds: int | None = None
+    sentiment_score: float | None = None
+    sentiment_label: str | None = None
+    topics: list[str]
+    summary: str | None = None
+
+
+class CallSearchResponse(BaseModel):
+    """Payload for the calls search endpoint."""
+
+    calls: list[CallSearchItem]
+    total: int
+    page: int
+    per_page: int
 
 
 # =============================================================================
@@ -148,6 +173,105 @@ def _get_supervisor_id_for_call_metadata(
 # =============================================================================
 
 
+@router.get("/", response_model=CallSearchResponse)
+def get_calls(
+    current_user: Annotated[dict, Depends(get_current_user)],
+    client: Annotated[Any, Depends(get_supabase_client)],
+    q: str | None = None,
+    agent_id: str | None = None,
+    sentiment_min: float | None = None,
+    sentiment_max: float | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    topic: str | None = None,
+    sort: str = "recent",
+    page: int = 1,
+    per_page: int = 20,
+) -> CallSearchResponse:
+    """Retrieve conversations that match selected filters."""
+    db_client = _require_client(client)
+    team_id = _get_user_team_id(current_user)
+
+    try:
+        sort_enum = SortOrder(sort)
+    except ValueError:
+        # Fallback to recent if an invalid sort string is provided
+        sort_enum = SortOrder.RECENT
+
+    try:
+        search_result = search_calls(
+            client=db_client,
+            team_id=team_id,
+            agent_id=agent_id,
+            date_from=date_from,
+            date_to=date_to,
+            sentiment_min=sentiment_min,
+            sentiment_max=sentiment_max,
+            keyword=q,
+            topic=topic,
+            sort=sort_enum,
+            page=page,
+            per_page=per_page,
+        )
+
+        calls_data = search_result.get("calls", [])
+        total = search_result.get("total", 0)
+
+        formatted_calls = []
+        for call in calls_data:
+            agent_details = (
+                get_user_by_id(db_client, call["agent_id"]) if call.get("agent_id") else {}
+            )
+            agent_name_parts = [agent_details.get("first_name"), agent_details.get("last_name")]
+            agent_name = " ".join(part for part in agent_name_parts if part) or agent_details.get(
+                "email", "Unknown Agent"
+            )
+
+            analysis = call.get(Tables.CALL_ANALYSES, {})
+
+            if isinstance(analysis, list) and analysis:
+                analysis = analysis[0]
+            elif isinstance(analysis, list):
+                analysis = {}
+
+            # Extract topics from junction table if present
+            topics = []
+            for t in analysis.get(Tables.CALL_ANALYSIS_TOPICS, []):
+                topic_data = t.get(Tables.TOPICS)
+                if topic_data and isinstance(topic_data, dict):
+                    name = topic_data.get("name")
+                    if name:
+                        topics.append(name)
+
+            formatted_calls.append(
+                CallSearchItem(
+                    id=call["id"],
+                    agent_id=call["agent_id"],
+                    agent_name=agent_name,
+                    started_at=call.get("started_at"),
+                    duration_seconds=call.get("duration_seconds"),
+                    sentiment_score=analysis.get("sentiment_score"),
+                    sentiment_label=analysis.get("sentiment_label"),
+                    topics=topics,
+                    summary=analysis.get("summary"),
+                )
+            )
+
+        return CallSearchResponse(
+            calls=formatted_calls,
+            total=total,
+            page=page,
+            per_page=per_page,
+        )
+
+    except DatabaseError as exc:
+        logger.error(f"Database error during call search: {exc}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to search calls",
+        ) from exc
+
+
 @router.get("/{call_id}", response_model=CallDetailResponse)
 def get_call_detail(
     call_id: str,
@@ -181,6 +305,9 @@ def get_call_detail(
 
         transcript = _normalize_transcript(call.get("transcript"))
 
+        topics = analysis.get("topics", []) if analysis else []
+        keywords = analysis.get("keywords", []) if analysis else []
+
         return CallDetailResponse(
             id=call["id"],
             agent_id=call["agent_id"],
@@ -193,7 +320,8 @@ def get_call_detail(
             sentiment_score=analysis.get("sentiment_score") if analysis else None,
             sentiment_label=analysis.get("sentiment_label") if analysis else None,
             is_resolved=analysis.get("is_resolved") if analysis else None,
-            topics=analysis.get("topics", []) if analysis else [],
+            topics=topics,
+            keywords=keywords,
             summary=analysis.get("summary") if analysis else None,
             transcript=[CallDetailTranscriptTurn(**turn) for turn in transcript],
             has_open_alert=open_alert is not None,

--- a/backend/database/calls.py
+++ b/backend/database/calls.py
@@ -74,6 +74,10 @@ def search_calls(
     client: Client,
     team_id: str,
     agent_id: str = None,
+    sentiment_min: float = None,
+    sentiment_max: float = None,
+    keyword: str = None,
+    topic: str = None,
     date_from: str = None,
     date_to: str = None,
     sort: SortOrder = SortOrder.RECENT,
@@ -85,8 +89,6 @@ def search_calls(
 
     page: min 1
     per_page: max 100
-
-    TODO: sentiment filter/sort (needs calls_with_analysis view)
     """
     if page < 1:
         page = 1
@@ -94,7 +96,11 @@ def search_calls(
 
     query = (
         client.table(Tables.CALLS)
-        .select(f"*, {Tables.CALL_ANALYSES}(*)", count="exact")
+        .select(
+            f"*, {Tables.CALL_ANALYSES}!inner(*, "
+            f"{Tables.CALL_ANALYSIS_TOPICS}({Tables.TOPICS}(name)))",
+            count="exact",
+        )
         .eq("team_id", team_id)
     )
 
@@ -105,6 +111,15 @@ def search_calls(
     if date_to is not None:
         next_day = (datetime.fromisoformat(date_to) + timedelta(days=1)).strftime("%Y-%m-%d")
         query = query.lt("started_at", next_day)
+
+    if sentiment_min is not None:
+        query = query.gte(f"{Tables.CALL_ANALYSES}.sentiment_score", sentiment_min)
+    if sentiment_max is not None:
+        query = query.lte(f"{Tables.CALL_ANALYSES}.sentiment_score", sentiment_max)
+    if keyword:
+        query = query.ilike("call_analyses.summary", f"%{keyword}%")
+    if topic:
+        query = query.contains(f"{Tables.CALL_ANALYSES}.topics", f'["{topic}"]')
 
     if sort == SortOrder.OLDEST:
         query = query.order("started_at", desc=False)

--- a/backend/tests/test_calls_routes.py
+++ b/backend/tests/test_calls_routes.py
@@ -442,6 +442,7 @@ def test_get_call_detail_returns_call_for_same_team(
             {"speaker": "Customer", "text": "I need help with a refund.", "timestamp": None},
             {"speaker": "Agent", "text": "I can help with that.", "timestamp": None},
         ],
+        "keywords": [],
     }
 
 
@@ -467,3 +468,70 @@ def test_get_call_detail_returns_404_for_other_team(
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Call call-123 not found"}
+
+
+def test_search_calls_endpoint(
+    authenticated_supervisor_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GET /api/calls should correctly parse query parameters and return a list of call results."""
+    from database.constants import SortOrder
+
+    mock_search_result = {
+        "calls": [
+            {
+                "id": "call-1",
+                "agent_id": "agent-1",
+                "started_at": "2026-03-10T12:00:00Z",
+                "duration_seconds": 120,
+                "call_analyses": [
+                    {
+                        "sentiment_score": -0.6,
+                        "sentiment_label": "negative",
+                        "topics": ["refund"],
+                        "summary": "test summary",
+                    }
+                ],
+            }
+        ],
+        "total": 1,
+    }
+
+    mock_search = MagicMock(return_value=mock_search_result)
+    mock_get_user = MagicMock(return_value={"first_name": "Marcus", "last_name": "Johnson"})
+
+    monkeypatch.setattr(calls_router, "search_calls", mock_search)
+    monkeypatch.setattr(calls_router, "get_user_by_id", mock_get_user)
+
+    response = authenticated_supervisor_client.get(
+        "/api/calls",
+        params={
+            "q": "refund",
+            "sentiment_min": -0.8,
+            "sentiment_max": -0.2,
+            "agent_id": "agent-1",
+            "sort": "recent",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert len(data["calls"]) == 1
+    assert data["calls"][0]["agent_name"] == "Marcus Johnson"
+    assert data["calls"][0]["sentiment_score"] == -0.6
+
+    mock_search.assert_called_once_with(
+        client=ANY,
+        team_id="team-456",
+        agent_id="agent-1",
+        date_from=None,
+        date_to=None,
+        sentiment_min=-0.8,
+        sentiment_max=-0.2,
+        keyword="refund",
+        topic=None,
+        sort=SortOrder.RECENT,
+        page=1,
+        per_page=20,
+    )


### PR DESCRIPTION
## Summary
This PR transitions the call search and detail endpoints to use live database records.

## Changes
- Implemented the search_calls database operation with robust filtering (by agent, sentiment, date, topic, and keyword).

## Test Plan
- Relevant calls returned for keyword queries
- Endpoint returned filtered/search results
