### PR TITLE
Frontend PR: Live Call Search 

### DIFF
--- a/backend/api/routers/calls.py
+++ b/backend/api/routers/calls.py
@@ -17,8 +17,9 @@ from database.analysis import (
     create_analysis,
     get_analysis_by_call_id,
 )
-from database.calls import create_call
+from database.calls import create_call, search_calls
 from database.calls import get_call_by_id as fetch_call_by_id
+from database.constants import SortOrder, Tables
 from database.exceptions import DatabaseError, NotFoundError
 from database.sample_transcripts import get_random_sample_transcript
 from database.teams import get_team_by_id
@@ -80,10 +81,34 @@ class CallDetailResponse(BaseModel):
     sentiment_label: str | None = None
     is_resolved: bool | None = None
     topics: list[str]
+    keywords: list[str] = []
     summary: str | None = None
     transcript: list[CallDetailTranscriptTurn]
     has_open_alert: bool = False
     open_alert_id: str | None = None
+
+
+class CallSearchItem(BaseModel):
+    """A minimal call representation returned in search results."""
+
+    id: str
+    agent_id: str
+    agent_name: str
+    started_at: str | None = None
+    duration_seconds: int | None = None
+    sentiment_score: float | None = None
+    sentiment_label: str | None = None
+    topics: list[str]
+    summary: str | None = None
+
+
+class CallSearchResponse(BaseModel):
+    """Payload for the calls search endpoint."""
+
+    calls: list[CallSearchItem]
+    total: int
+    page: int
+    per_page: int
 
 
 # =============================================================================
@@ -148,6 +173,105 @@ def _get_supervisor_id_for_call_metadata(
 # =============================================================================
 
 
+@router.get("/", response_model=CallSearchResponse)
+def get_calls(
+    current_user: Annotated[dict, Depends(get_current_user)],
+    client: Annotated[Any, Depends(get_supabase_client)],
+    q: str | None = None,
+    agent_id: str | None = None,
+    sentiment_min: float | None = None,
+    sentiment_max: float | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    topic: str | None = None,
+    sort: str = "recent",
+    page: int = 1,
+    per_page: int = 20,
+) -> CallSearchResponse:
+    """Retrieve conversations that match selected filters."""
+    db_client = _require_client(client)
+    team_id = _get_user_team_id(current_user)
+
+    try:
+        sort_enum = SortOrder(sort)
+    except ValueError:
+        # Fallback to recent if an invalid sort string is provided
+        sort_enum = SortOrder.RECENT
+
+    try:
+        search_result = search_calls(
+            client=db_client,
+            team_id=team_id,
+            agent_id=agent_id,
+            date_from=date_from,
+            date_to=date_to,
+            sentiment_min=sentiment_min,
+            sentiment_max=sentiment_max,
+            keyword=q,
+            topic=topic,
+            sort=sort_enum,
+            page=page,
+            per_page=per_page,
+        )
+
+        calls_data = search_result.get("calls", [])
+        total = search_result.get("total", 0)
+
+        formatted_calls = []
+        for call in calls_data:
+            agent_details = (
+                get_user_by_id(db_client, call["agent_id"]) if call.get("agent_id") else {}
+            )
+            agent_name_parts = [agent_details.get("first_name"), agent_details.get("last_name")]
+            agent_name = " ".join(part for part in agent_name_parts if part) or agent_details.get(
+                "email", "Unknown Agent"
+            )
+
+            analysis = call.get(Tables.CALL_ANALYSES, {})
+
+            if isinstance(analysis, list) and analysis:
+                analysis = analysis[0]
+            elif isinstance(analysis, list):
+                analysis = {}
+
+            # Extract topics from junction table if present
+            topics = []
+            for t in analysis.get(Tables.CALL_ANALYSIS_TOPICS, []):
+                topic_data = t.get(Tables.TOPICS)
+                if topic_data and isinstance(topic_data, dict):
+                    name = topic_data.get("name")
+                    if name:
+                        topics.append(name)
+
+            formatted_calls.append(
+                CallSearchItem(
+                    id=call["id"],
+                    agent_id=call["agent_id"],
+                    agent_name=agent_name,
+                    started_at=call.get("started_at"),
+                    duration_seconds=call.get("duration_seconds"),
+                    sentiment_score=analysis.get("sentiment_score"),
+                    sentiment_label=analysis.get("sentiment_label"),
+                    topics=topics,
+                    summary=analysis.get("summary"),
+                )
+            )
+
+        return CallSearchResponse(
+            calls=formatted_calls,
+            total=total,
+            page=page,
+            per_page=per_page,
+        )
+
+    except DatabaseError as exc:
+        logger.error(f"Database error during call search: {exc}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to search calls",
+        ) from exc
+
+
 @router.get("/{call_id}", response_model=CallDetailResponse)
 def get_call_detail(
     call_id: str,
@@ -181,6 +305,9 @@ def get_call_detail(
 
         transcript = _normalize_transcript(call.get("transcript"))
 
+        topics = analysis.get("topics", []) if analysis else []
+        keywords = analysis.get("keywords", []) if analysis else []
+
         return CallDetailResponse(
             id=call["id"],
             agent_id=call["agent_id"],
@@ -193,7 +320,8 @@ def get_call_detail(
             sentiment_score=analysis.get("sentiment_score") if analysis else None,
             sentiment_label=analysis.get("sentiment_label") if analysis else None,
             is_resolved=analysis.get("is_resolved") if analysis else None,
-            topics=analysis.get("topics", []) if analysis else [],
+            topics=topics,
+            keywords=keywords,
             summary=analysis.get("summary") if analysis else None,
             transcript=[CallDetailTranscriptTurn(**turn) for turn in transcript],
             has_open_alert=open_alert is not None,

--- a/backend/database/calls.py
+++ b/backend/database/calls.py
@@ -74,6 +74,10 @@ def search_calls(
     client: Client,
     team_id: str,
     agent_id: str = None,
+    sentiment_min: float = None,
+    sentiment_max: float = None,
+    keyword: str = None,
+    topic: str = None,
     date_from: str = None,
     date_to: str = None,
     sort: SortOrder = SortOrder.RECENT,
@@ -85,8 +89,6 @@ def search_calls(
 
     page: min 1
     per_page: max 100
-
-    TODO: sentiment filter/sort (needs calls_with_analysis view)
     """
     if page < 1:
         page = 1
@@ -94,7 +96,11 @@ def search_calls(
 
     query = (
         client.table(Tables.CALLS)
-        .select(f"*, {Tables.CALL_ANALYSES}(*)", count="exact")
+        .select(
+            f"*, {Tables.CALL_ANALYSES}!inner(*, "
+            f"{Tables.CALL_ANALYSIS_TOPICS}({Tables.TOPICS}(name)))",
+            count="exact",
+        )
         .eq("team_id", team_id)
     )
 
@@ -105,6 +111,15 @@ def search_calls(
     if date_to is not None:
         next_day = (datetime.fromisoformat(date_to) + timedelta(days=1)).strftime("%Y-%m-%d")
         query = query.lt("started_at", next_day)
+
+    if sentiment_min is not None:
+        query = query.gte(f"{Tables.CALL_ANALYSES}.sentiment_score", sentiment_min)
+    if sentiment_max is not None:
+        query = query.lte(f"{Tables.CALL_ANALYSES}.sentiment_score", sentiment_max)
+    if keyword:
+        query = query.ilike("call_analyses.summary", f"%{keyword}%")
+    if topic:
+        query = query.contains(f"{Tables.CALL_ANALYSES}.topics", f'["{topic}"]')
 
     if sort == SortOrder.OLDEST:
         query = query.order("started_at", desc=False)

--- a/backend/tests/test_calls_routes.py
+++ b/backend/tests/test_calls_routes.py
@@ -442,6 +442,7 @@ def test_get_call_detail_returns_call_for_same_team(
             {"speaker": "Customer", "text": "I need help with a refund.", "timestamp": None},
             {"speaker": "Agent", "text": "I can help with that.", "timestamp": None},
         ],
+        "keywords": [],
     }
 
 
@@ -467,3 +468,70 @@ def test_get_call_detail_returns_404_for_other_team(
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Call call-123 not found"}
+
+
+def test_search_calls_endpoint(
+    authenticated_supervisor_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GET /api/calls should correctly parse query parameters and return a list of call results."""
+    from database.constants import SortOrder
+
+    mock_search_result = {
+        "calls": [
+            {
+                "id": "call-1",
+                "agent_id": "agent-1",
+                "started_at": "2026-03-10T12:00:00Z",
+                "duration_seconds": 120,
+                "call_analyses": [
+                    {
+                        "sentiment_score": -0.6,
+                        "sentiment_label": "negative",
+                        "topics": ["refund"],
+                        "summary": "test summary",
+                    }
+                ],
+            }
+        ],
+        "total": 1,
+    }
+
+    mock_search = MagicMock(return_value=mock_search_result)
+    mock_get_user = MagicMock(return_value={"first_name": "Marcus", "last_name": "Johnson"})
+
+    monkeypatch.setattr(calls_router, "search_calls", mock_search)
+    monkeypatch.setattr(calls_router, "get_user_by_id", mock_get_user)
+
+    response = authenticated_supervisor_client.get(
+        "/api/calls",
+        params={
+            "q": "refund",
+            "sentiment_min": -0.8,
+            "sentiment_max": -0.2,
+            "agent_id": "agent-1",
+            "sort": "recent",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert len(data["calls"]) == 1
+    assert data["calls"][0]["agent_name"] == "Marcus Johnson"
+    assert data["calls"][0]["sentiment_score"] == -0.6
+
+    mock_search.assert_called_once_with(
+        client=ANY,
+        team_id="team-456",
+        agent_id="agent-1",
+        date_from=None,
+        date_to=None,
+        sentiment_min=-0.8,
+        sentiment_max=-0.2,
+        keyword="refund",
+        topic=None,
+        sort=SortOrder.RECENT,
+        page=1,
+        per_page=20,
+    )

--- a/frontend/src/components/CallDetailDrawer.tsx
+++ b/frontend/src/components/CallDetailDrawer.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Call, CallSummary } from '@/lib/mock-data';
 import { MockService } from '@/lib/mock-service';
+import { callsApi, SupervisorCallDetail } from '@/lib/api';
 import { useAppStore } from '@/stores/app-store';
 import { useAuthStore } from '@/stores/auth-store';
 import { SentimentBadge } from './SentimentBadge';
@@ -26,7 +27,7 @@ import {
 } from 'lucide-react';
 import { toast } from '@/hooks/use-toast';
 
-type CallDetailCall = Call & {
+export type CallDetailCall = Call & {
   hasOpenAlert?: boolean;
   openAlertId?: string | null;
   callSummary?: {
@@ -56,13 +57,45 @@ export function CallDetailDrawer({
   onCreateAlert,
 }: CallDetailDrawerProps) {
   const [newNote, setNewNote] = useState('');
+  const [liveCallDetail, setLiveCallDetail] = useState<SupervisorCallDetail | null>(null);
+  const [loadingDetail, setLoadingDetail] = useState(false);
+
+  useEffect(() => {
+    if (call && open) {
+      setLoadingDetail(true);
+      callsApi.getCallById(call.id).then(res => {
+        setLiveCallDetail(res);
+      }).catch(err => {
+        console.error('Failed to fetch call details', err);
+      }).finally(() => setLoadingDetail(false));
+    } else {
+      setLiveCallDetail(null);
+    }
+  }, [call, open]);
+
   const { user } = useAuthStore();
   const { exemplarCallIds, toggleExemplar, callNotes, addNote } = useAppStore();
 
   if (!call) return null;
 
-  const summary: CallSummary | CallDetailCall['callSummary'] | undefined =
-    call.callSummary ?? MockService.getSummary(call.id);
+  let summaryText = '';
+  let transcript = [] as Array<{ speaker: string; text: string; timestamp?: string }>;
+  let topics: string[] = [];
+  let keywords: string[] = [];
+  let isResolved = call?.resolved || false;
+  
+  if (liveCallDetail) {
+    summaryText = liveCallDetail.summary || '';
+    transcript = liveCallDetail.transcript || [];
+    topics = liveCallDetail.topics || [];
+    keywords = liveCallDetail.keywords || [];
+    isResolved = liveCallDetail.is_resolved ?? isResolved;
+  } else if (call) {
+    const backupSummary = call.callSummary ?? MockService.getSummary(call.id);
+    summaryText = backupSummary?.summaryText || (call as Call & { summaryStr?: string })?.summaryStr || '';
+    transcript = backupSummary?.transcript || [];
+    topics = call.topics || [];
+  }
   const isExemplar = exemplarCallIds.includes(call.id);
   const notes = callNotes.filter((n) => n.callId === call.id);
 
@@ -125,7 +158,7 @@ export function CallDetailDrawer({
               </div>
               <div className="space-y-1">
                 <p className="text-sm text-muted-foreground">Customer</p>
-                <p className="font-medium">{call.customerName}</p>
+                <p className="font-medium">{'Customer'}</p>
               </div>
               <div className="space-y-1">
                 <p className="text-sm text-muted-foreground">Duration</p>
@@ -147,7 +180,7 @@ export function CallDetailDrawer({
               <div className="space-y-1">
                 <p className="text-sm text-muted-foreground">Resolution</p>
                 <p className="font-medium flex items-center gap-2">
-                  {call.resolved ? (
+                  {isResolved ? (
                     <>
                       <CheckCircle className="h-4 w-4 text-success" />
                       Resolved
@@ -166,7 +199,7 @@ export function CallDetailDrawer({
             <div>
               <p className="text-sm text-muted-foreground mb-2">Topics</p>
               <div className="flex flex-wrap gap-2">
-                {call.topics.map((topic) => (
+                {topics.map((topic) => (
                   <Badge key={topic} variant="secondary">
                     {topic.replace(/-/g, ' ')}
                   </Badge>
@@ -175,31 +208,29 @@ export function CallDetailDrawer({
             </div>
 
             {/* Summary */}
-            {summary && (
-              <div className="p-4 bg-muted/50 rounded-lg">
-                <h4 className="font-semibold mb-2">AI Summary</h4>
-                <p className="text-sm text-muted-foreground">{summary.summaryText}</p>
-                {summary.keyPhrases.length > 0 && (
-                  <div className="mt-3">
-                    <p className="text-xs text-muted-foreground mb-1">Key Phrases</p>
-                    <div className="flex flex-wrap gap-1">
-                      {summary.keyPhrases.map((phrase) => (
-                        <Badge key={phrase} variant="outline" className="text-xs">
-                          {phrase}
-                        </Badge>
-                      ))}
-                    </div>
+            <div className="p-4 bg-muted/50 rounded-lg">
+              <h4 className="font-semibold mb-2">AI Summary</h4>
+              <p className="text-sm text-muted-foreground">{loadingDetail ? 'Loading summary...' : (summaryText || 'Summary not available.')}</p>
+              {keywords.length > 0 && (
+                <div className="mt-3">
+                  <p className="text-xs text-muted-foreground mb-1">Key Phrases</p>
+                  <div className="flex flex-wrap gap-1">
+                    {keywords.map((phrase) => (
+                      <Badge key={phrase} variant="outline" className="text-xs">
+                        {phrase}
+                      </Badge>
+                    ))}
                   </div>
-                )}
-              </div>
-            )}
+                </div>
+              )}
+            </div>
 
             {/* Transcript */}
-            {summary?.transcript && (
+            {transcript && transcript.length > 0 && (
               <div>
                 <h4 className="font-semibold mb-3">Transcript</h4>
                 <div className="space-y-3">
-                  {summary.transcript.map((turn, idx) => (
+                  {transcript.map((turn, idx) => (
                     <div
                       key={idx}
                       className={`p-3 rounded-lg ${
@@ -269,7 +300,7 @@ export function CallDetailDrawer({
                 <Star className={`h-4 w-4 mr-2 ${isExemplar ? 'fill-current' : ''}`} />
                 {isExemplar ? 'Remove Exemplar' : 'Mark as Exemplar'}
               </Button>
-              {canCreateAlert && !call.hasOpenAlert && onCreateAlert && (
+              {canCreateAlert && !liveCallDetail?.has_open_alert && !call?.hasOpenAlert && onCreateAlert && (
                 <Button
                   variant="outline"
                   size="sm"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -399,6 +399,38 @@ export const alertsApi = {
 // Calls API Types
 // =============================================================================
 
+export interface CallSearchParams {
+  q?: string;
+  agent_id?: string;
+  sentiment_min?: number;
+  sentiment_max?: number;
+  date_from?: string;
+  date_to?: string;
+  topic?: string;
+  sort?: string;
+  page?: number;
+  per_page?: number;
+}
+
+export interface CallSearchItem {
+  id: string;
+  agent_id: string;
+  agent_name: string | null;
+  started_at: string | null;
+  duration_seconds: number | null;
+  sentiment_score: number | null;
+  sentiment_label: string | null;
+  topics: string[];
+  summary: string | null;
+}
+
+export interface CallSearchResponse {
+  calls: CallSearchItem[];
+  total: number;
+  page: number;
+  per_page: number;
+}
+
 export interface SimulateCallResponse {
   call_id: string;
   sentiment_score: number;
@@ -425,6 +457,7 @@ export interface SupervisorCallDetail {
   sentiment_label: 'positive' | 'neutral' | 'negative' | null;
   is_resolved: boolean | null;
   topics: string[];
+  keywords?: string[];
   summary: string | null;
   has_open_alert: boolean;
   open_alert_id: string | null;
@@ -440,6 +473,16 @@ export interface SupervisorCallDetail {
 // =============================================================================
 
 export const callsApi = {
+  searchCalls: (params: CallSearchParams) => {
+    const query = new URLSearchParams();
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '') {
+        query.append(key, value.toString());
+      }
+    });
+    return api.get<CallSearchResponse>(`/api/calls?${query.toString()}`);
+  },
+
   getCallById: (callId: string) =>
     api.get<SupervisorCallDetail>(`/api/calls/${callId}`),
 

--- a/frontend/src/pages/supervisor/Search.tsx
+++ b/frontend/src/pages/supervisor/Search.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { mockData } from '@/lib/mock-data';
 import type { Call } from '@/lib/mock-data';
 import { MockService, SearchResult } from '@/lib/mock-service';
-import { CallDetailDrawer } from '@/components/CallDetailDrawer';
+import { callsApi, teamsApi, alertsApi, AgentInfo } from '@/lib/api';
+import { CallDetailDrawer, CallDetailCall } from '@/components/CallDetailDrawer';
 import { Card } from '@/components/ui/card';
 import { toast } from '@/hooks/use-toast';
 import { Search as SearchIcon } from 'lucide-react';
@@ -19,12 +20,43 @@ export default function CallSearch() {
   const [loading, setLoading] = useState(false);
   const [selectedCall, setSelectedCall] = useState<Call | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [isCreatingAlert, setIsCreatingAlert] = useState(false);
+  const [agents, setAgents] = useState<AgentInfo[]>([]);
+
+  useEffect(() => {
+    teamsApi.getMembers().then(res => {
+      setAgents(res.members || []);
+    }).catch(err => console.error('Failed to load agents:', err));
+  }, []);
+
+  const handleCreateAlert = async (callId: string) => {
+    setIsCreatingAlert(true);
+    try {
+      const createdAlert = await alertsApi.createManualAlert({ call_id: callId });
+      setSelectedCall((prev) =>
+        prev && prev.id === callId
+          ? { ...prev, hasOpenAlert: true, openAlertId: createdAlert.id } as Call
+          : prev
+      );
+      toast({
+        title: 'Alert Created',
+        description: 'The call has been flagged for manual review.',
+      });
+    } catch (err) {
+      console.error('Failed to create manual alert', err);
+      toast({
+        title: 'Error',
+        description: 'Failed to flag call.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsCreatingAlert(false);
+    }
+  };
 
   const handleAgentToggle = (agentId: string) => {
     setSelectedAgentIds((prev) =>
-      prev.includes(agentId)
-        ? prev.filter((id) => id !== agentId)
-        : [...prev, agentId]
+      prev.includes(agentId) ? [] : [agentId]
     );
   };
 
@@ -35,17 +67,48 @@ export default function CallSearch() {
   const handleSearch = async (page = 1) => {
     setLoading(true);
     try {
-      const result = await MockService.searchCalls({
-        keyword: keyword || undefined,
-        agentIds: selectedAgentIds.length > 0 ? selectedAgentIds : undefined,
-        sentimentMin: sentimentRange[0],
-        sentimentMax: sentimentRange[1],
-        dateFrom: dateFrom || undefined,
-        dateTo: dateTo || undefined,
+      const agentIdParam = selectedAgentIds.length > 0 ? selectedAgentIds[0] : undefined;
+      
+      const data = await callsApi.searchCalls({
+        q: keyword || undefined,
+        agent_id: agentIdParam,
+        sentiment_min: sentimentRange[0],
+        sentiment_max: sentimentRange[1],
+        date_from: dateFrom || undefined,
+        date_to: dateTo || undefined,
         page,
-        pageSize: 20,
+        per_page: 20,
       });
-      setResults(result);
+
+      const mappedResult: SearchResult = {
+        calls: data.calls.map((c) => ({
+          id: c.id,
+          agentId: c.agent_id,
+          agentName: c.agent_name || 'Unknown',
+          startedAt: c.started_at || new Date().toISOString(),
+          durationSec: c.duration_seconds || 0,
+          sentimentScore: c.sentiment_score || 0,
+          sentimentLabel: (c.sentiment_label as 'positive' | 'neutral' | 'negative') || 'neutral',
+          topics: c.topics || [],
+          resolved: false,
+          csat: null,
+          customerName: 'Unknown Customer',
+          summaryStr: c.summary,
+        } as unknown as Call)),
+        total: data.total,
+        page: data.page,
+        pageSize: data.per_page,
+        totalPages: Math.ceil(data.total / data.per_page) || 1,
+      };
+      
+      setResults(mappedResult);
+    } catch (error) {
+      console.error('Search error:', error);
+      toast({
+        title: 'Error',
+        description: 'Failed to search calls.',
+        variant: 'destructive',
+      });
     } finally {
       setLoading(false);
     }
@@ -89,6 +152,10 @@ export default function CallSearch() {
   };
 
   const getSnippet = (call: Call): string => {
+    const extendedCall = call as Call & { summaryStr?: string };
+    if (extendedCall.summaryStr) {
+      return extendedCall.summaryStr;
+    }
     const summary = MockService.getSummary(call.id);
     if (summary?.transcript) {
       for (const turn of summary.transcript) {
@@ -108,7 +175,7 @@ export default function CallSearch() {
   };
 
   const selectedAgentNames = selectedAgentIds
-    .map((id) => mockData.agents.find((a) => a.id === id)?.name)
+    .map((id) => agents.find((a) => a.id === id) ? `${agents.find((a) => a.id === id)?.first_name || ''} ${agents.find((a) => a.id === id)?.last_name || ''}`.trim() || agents.find((a) => a.id === id)?.email : undefined)
     .filter((n): n is string => Boolean(n));
 
   return (
@@ -117,7 +184,13 @@ export default function CallSearch() {
         keyword={keyword}
         selectedAgentIds={selectedAgentIds}
         selectedAgentNames={selectedAgentNames}
-        agents={mockData.agents}
+        agents={agents.map(a => ({
+          id: a.id,
+          name: `${a.first_name || ''} ${a.last_name || ''}`.trim() || a.email,
+          team: 'Team',
+          hireDate: new Date().toISOString(),
+          status: 'active' as const
+        }))}
         sentimentRange={sentimentRange}
         dateFrom={dateFrom}
         dateTo={dateTo}
@@ -160,9 +233,12 @@ export default function CallSearch() {
       )}
 
       <CallDetailDrawer
-        call={selectedCall}
+        call={selectedCall as CallDetailCall}
         open={drawerOpen}
         onOpenChange={setDrawerOpen}
+        canCreateAlert
+        isCreatingAlert={isCreatingAlert}
+        onCreateAlert={handleCreateAlert}
       />
     </div>
   );

--- a/frontend/src/pages/supervisor/components/SearchFilters.tsx
+++ b/frontend/src/pages/supervisor/components/SearchFilters.tsx
@@ -66,7 +66,7 @@ export function SearchFilters({
           />
         </div>
         <div className="space-y-2">
-          <Label>Agents</Label>
+          <Label>Agent</Label>
           <Popover>
             <PopoverTrigger asChild>
               <Button
@@ -74,10 +74,10 @@ export function SearchFilters({
                 className="w-full justify-between font-normal"
               >
                 {selectedAgentIds.length === 0 ? (
-                  <span className="text-muted-foreground">Select agents...</span>
+                  <span className="text-muted-foreground">Select agent...</span>
                 ) : (
                   <span className="truncate">
-                    {selectedAgentIds.length} agent{selectedAgentIds.length !== 1 ? 's' : ''} selected
+                    {selectedAgentNames[0]}
                   </span>
                 )}
                 <ChevronDown className="h-4 w-4 ml-2 shrink-0 opacity-50" />
@@ -86,7 +86,7 @@ export function SearchFilters({
             <PopoverContent className="w-64 p-0" align="start">
               <div className="p-2 border-b">
                 <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium">Select Agents</span>
+                  <span className="text-sm font-medium">Select Agent</span>
                   {selectedAgentIds.length > 0 && (
                     <Button
                       variant="ghost"
@@ -94,7 +94,7 @@ export function SearchFilters({
                       className="h-auto p-1 text-xs"
                       onClick={onClearAgents}
                     >
-                      Clear all
+                      Clear
                     </Button>
                   )}
                 </div>
@@ -118,20 +118,6 @@ export function SearchFilters({
               </div>
             </PopoverContent>
           </Popover>
-          {selectedAgentIds.length > 0 && (
-            <div className="flex flex-wrap gap-1 mt-2">
-              {selectedAgentNames.slice(0, 3).map((name) => (
-                <Badge key={name} variant="secondary" className="text-xs">
-                  {name}
-                </Badge>
-              ))}
-              {selectedAgentIds.length > 3 && (
-                <Badge variant="outline" className="text-xs">
-                  +{selectedAgentIds.length - 3} more
-                </Badge>
-              )}
-            </div>
-          )}
         </div>
         <div className="space-y-2">
           <Label>


### PR DESCRIPTION
## Summary
This PR replaces dummy mock data within the Supervisor search interface with the live backend API.

## Changes
- Transitioned `Search.tsx` to use `callsApi`for fetching actual agents, paginated call lists, and dynamic search filtering.
- Connected `CallDetailDrawer.tsx` to fetch deep live metadata upon expanding a selected call.


## Test Plan
- Results render correctly
- Results update based on filters/search
