### PR TITLE
feat(ux): polish alert loading states and pagination behavior

### DIFF
--- a/backend/database/calls.py
+++ b/backend/database/calls.py
@@ -1,5 +1,7 @@
 """Call record helpers."""
 
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 
 from supabase import Client
@@ -9,6 +11,37 @@ from .decorators import db_operation
 from .exceptions import NotFoundError
 
 MAX_PER_PAGE = 100
+
+
+def _apply_call_search_filters(
+    query,
+    *,
+    agent_id: str | None,
+    date_from: str | None,
+    date_to: str | None,
+    sentiment_min: float | None,
+    sentiment_max: float | None,
+    keyword: str | None,
+    topic: str | None,
+):
+    """Apply shared filters for call search (calls + inner call_analyses)."""
+    if agent_id is not None:
+        query = query.eq("agent_id", agent_id)
+    if date_from is not None:
+        query = query.gte("started_at", date_from)
+    if date_to is not None:
+        next_day = (datetime.fromisoformat(date_to) + timedelta(days=1)).strftime("%Y-%m-%d")
+        query = query.lt("started_at", next_day)
+
+    if sentiment_min is not None:
+        query = query.gte(f"{Tables.CALL_ANALYSES}.sentiment_score", sentiment_min)
+    if sentiment_max is not None:
+        query = query.lte(f"{Tables.CALL_ANALYSES}.sentiment_score", sentiment_max)
+    if keyword:
+        query = query.ilike("call_analyses.summary", f"%{keyword}%")
+    if topic:
+        query = query.contains(f"{Tables.CALL_ANALYSES}.topics", f'["{topic}"]')
+    return query
 
 
 @db_operation
@@ -94,32 +127,44 @@ def search_calls(
         page = 1
     per_page = min(per_page, MAX_PER_PAGE)
 
+    # Count distinct calls: join only analyses (1:1). Embedding call_analysis_topics
+    # multiplies rows and inflates PostgREST count="exact" vs. the paged rows.
+    count_query = (
+        client.table(Tables.CALLS)
+        .select(f"id,{Tables.CALL_ANALYSES}!inner(id)", count="exact")
+        .eq("team_id", team_id)
+    )
+    count_query = _apply_call_search_filters(
+        count_query,
+        agent_id=agent_id,
+        date_from=date_from,
+        date_to=date_to,
+        sentiment_min=sentiment_min,
+        sentiment_max=sentiment_max,
+        keyword=keyword,
+        topic=topic,
+    )
+    count_result = count_query.execute()
+    total = count_result.count if count_result.count is not None else 0
+
     query = (
         client.table(Tables.CALLS)
         .select(
             f"*, {Tables.CALL_ANALYSES}!inner(*, "
             f"{Tables.CALL_ANALYSIS_TOPICS}({Tables.TOPICS}(name)))",
-            count="exact",
         )
         .eq("team_id", team_id)
     )
-
-    if agent_id is not None:
-        query = query.eq("agent_id", agent_id)
-    if date_from is not None:
-        query = query.gte("started_at", date_from)
-    if date_to is not None:
-        next_day = (datetime.fromisoformat(date_to) + timedelta(days=1)).strftime("%Y-%m-%d")
-        query = query.lt("started_at", next_day)
-
-    if sentiment_min is not None:
-        query = query.gte(f"{Tables.CALL_ANALYSES}.sentiment_score", sentiment_min)
-    if sentiment_max is not None:
-        query = query.lte(f"{Tables.CALL_ANALYSES}.sentiment_score", sentiment_max)
-    if keyword:
-        query = query.ilike("call_analyses.summary", f"%{keyword}%")
-    if topic:
-        query = query.contains(f"{Tables.CALL_ANALYSES}.topics", f'["{topic}"]')
+    query = _apply_call_search_filters(
+        query,
+        agent_id=agent_id,
+        date_from=date_from,
+        date_to=date_to,
+        sentiment_min=sentiment_min,
+        sentiment_max=sentiment_max,
+        keyword=keyword,
+        topic=topic,
+    )
 
     if sort == SortOrder.OLDEST:
         query = query.order("started_at", desc=False)
@@ -131,4 +176,4 @@ def search_calls(
     query = query.range(offset, offset + per_page - 1)
 
     result = query.execute()
-    return {"calls": result.data, "total": result.count}
+    return {"calls": result.data, "total": total}

--- a/backend/tests/test_database_calls.py
+++ b/backend/tests/test_database_calls.py
@@ -3,7 +3,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from database.calls import create_call
+from database.calls import create_call, search_calls
 from database.constants import Tables
 
 
@@ -37,3 +37,36 @@ def test_create_call_includes_transcript_when_provided() -> None:
         }
     )
     assert result["id"] == "call-123"
+
+
+def test_search_calls_total_uses_distinct_count_query() -> None:
+    """total must match the count query, not a join-inflated row count from topic embeds."""
+    client = MagicMock()
+
+    def make_chain(execute_result):
+        chain = MagicMock()
+        chain.select.return_value = chain
+        chain.eq.return_value = chain
+        chain.gte.return_value = chain
+        chain.lte.return_value = chain
+        chain.lt.return_value = chain
+        chain.ilike.return_value = chain
+        chain.contains.return_value = chain
+        chain.order.return_value = chain
+        chain.range.return_value = chain
+        chain.execute.return_value = execute_result
+        return chain
+
+    count_result = SimpleNamespace(data=[], count=3)
+    data_result = SimpleNamespace(
+        data=[{"id": "call-1", "call_analyses": []}],
+        count=99,
+    )
+    chains = iter([make_chain(count_result), make_chain(data_result)])
+    client.table.side_effect = lambda _name: next(chains)
+
+    result = search_calls(client, team_id="team-1", page=1, per_page=20)
+
+    assert result["total"] == 3
+    assert len(result["calls"]) == 1
+    assert client.table.call_count == 2

--- a/frontend/src/pages/supervisor/components/AlertDetail.tsx
+++ b/frontend/src/pages/supervisor/components/AlertDetail.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -10,6 +11,8 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { SentimentBadge } from '@/components/SentimentBadge';
 import { AlertTriangle, CheckCircle, User, Clock } from 'lucide-react';
 import type { SupervisorAlertViewModel, SupervisorCallViewModel } from '@/lib/supervisor-alerts';
+
+const MIN_RELATED_CALLS_SKELETON_MS = 250;
 
 export interface AlertDetailProps {
   alert: SupervisorAlertViewModel | null;
@@ -33,6 +36,10 @@ export function AlertDetail({
   severityClassName,
 }: AlertDetailProps) {
   const primaryCall = relatedCalls[0];
+  const showRelatedCallsSkeleton = useMinimumLoadingState(
+    isLoadingRelatedCalls,
+    MIN_RELATED_CALLS_SKELETON_MS
+  );
   const isRecurringAlert =
     alert?.type === 'recurring_topic' || alert?.type === 'recurring_keyword';
 
@@ -61,9 +68,9 @@ export function AlertDetail({
               <p className="text-sm text-muted-foreground">{alert.issue}</p>
             </div>
 
-            {!isRecurringAlert && (isLoadingRelatedCalls || primaryCall) && (
+            {!isRecurringAlert && (showRelatedCallsSkeleton || primaryCall) && (
               <div className="p-4 bg-muted/50 rounded-lg space-y-3">
-                {isLoadingRelatedCalls ? (
+                {showRelatedCallsSkeleton ? (
                   <div
                     className="space-y-3"
                     role="status"
@@ -121,7 +128,7 @@ export function AlertDetail({
 
             {isRecurringAlert && (
               <div className="p-4 bg-muted/50 rounded-lg space-y-3">
-                {isLoadingRelatedCalls ? (
+                {showRelatedCallsSkeleton ? (
                   <div
                     className="space-y-3"
                     role="status"
@@ -204,4 +211,23 @@ export function AlertDetail({
       </SheetContent>
     </Sheet>
   );
+}
+
+function useMinimumLoadingState(isLoading: boolean, minimumMs: number) {
+  const [showLoading, setShowLoading] = useState(isLoading);
+
+  useEffect(() => {
+    if (isLoading) {
+      setShowLoading(true);
+      return undefined;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setShowLoading(false);
+    }, minimumMs);
+
+    return () => window.clearTimeout(timeout);
+  }, [isLoading, minimumMs]);
+
+  return showLoading;
 }

--- a/frontend/src/pages/supervisor/components/AlertDetail.tsx
+++ b/frontend/src/pages/supervisor/components/AlertDetail.tsx
@@ -6,6 +6,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
+import { Skeleton } from '@/components/ui/skeleton';
 import { SentimentBadge } from '@/components/SentimentBadge';
 import { AlertTriangle, CheckCircle, User, Clock } from 'lucide-react';
 import type { SupervisorAlertViewModel, SupervisorCallViewModel } from '@/lib/supervisor-alerts';
@@ -60,34 +61,60 @@ export function AlertDetail({
               <p className="text-sm text-muted-foreground">{alert.issue}</p>
             </div>
 
-            {!isRecurringAlert && primaryCall && (
+            {!isRecurringAlert && (isLoadingRelatedCalls || primaryCall) && (
               <div className="p-4 bg-muted/50 rounded-lg space-y-3">
                 <h5 className="text-sm font-medium">Call Information</h5>
-                <div className="grid grid-cols-2 gap-3 text-sm">
-                  <div className="flex items-center gap-2">
-                    <User className="h-4 w-4 text-muted-foreground" />
-                    {primaryCall.agentName}
+                {isLoadingRelatedCalls ? (
+                  <div
+                    className="space-y-3"
+                    role="status"
+                    aria-label="Loading call information"
+                  >
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="flex items-center gap-2">
+                        <User className="h-4 w-4 text-muted-foreground" />
+                        <Skeleton className="h-4 w-24" />
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Clock className="h-4 w-4 text-muted-foreground" />
+                        <Skeleton className="h-4 w-16" />
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Skeleton className="h-4 w-20" />
+                      <Skeleton className="h-6 w-16 rounded-full" />
+                    </div>
+                    <Skeleton className="h-9 w-full" />
                   </div>
-                  <div className="flex items-center gap-2">
-                    <Clock className="h-4 w-4 text-muted-foreground" />
-                    {Math.floor(primaryCall.durationSec / 60)}m {primaryCall.durationSec % 60}s
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="text-muted-foreground">Sentiment:</span>
-                  <SentimentBadge sentiment={primaryCall.sentimentLabel} />
-                </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="w-full"
-                  onClick={() => {
-                    onOpenCall(primaryCall.id);
-                    onClose();
-                  }}
-                >
-                  View Full Call Details
-                </Button>
+                ) : primaryCall ? (
+                  <>
+                    <div className="grid grid-cols-2 gap-3 text-sm">
+                      <div className="flex items-center gap-2">
+                        <User className="h-4 w-4 text-muted-foreground" />
+                        {primaryCall.agentName}
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Clock className="h-4 w-4 text-muted-foreground" />
+                        {Math.floor(primaryCall.durationSec / 60)}m {primaryCall.durationSec % 60}s
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="text-muted-foreground">Sentiment:</span>
+                      <SentimentBadge sentiment={primaryCall.sentimentLabel} />
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="w-full"
+                      onClick={() => {
+                        onOpenCall(primaryCall.id);
+                        onClose();
+                      }}
+                    >
+                      View Full Call Details
+                    </Button>
+                  </>
+                ) : null}
               </div>
             )}
 
@@ -98,7 +125,21 @@ export function AlertDetail({
                   {alert?.matchedCount ? ` (${alert.matchedCount})` : ''}
                 </h5>
                 {isLoadingRelatedCalls ? (
-                  <p className="text-sm text-muted-foreground">Loading related calls...</p>
+                  <div
+                    className="space-y-2"
+                    role="status"
+                    aria-label="Loading affected calls"
+                  >
+                    {Array.from({ length: 3 }).map((_, index) => (
+                      <div
+                        key={index}
+                        className="flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3"
+                      >
+                        <Skeleton className="h-4 w-36" />
+                        <Skeleton className="h-6 w-16 rounded-full" />
+                      </div>
+                    ))}
+                  </div>
                 ) : relatedCalls.length > 0 ? (
                   <div className="space-y-2">
                     {relatedCalls.map((call) => (

--- a/frontend/src/pages/supervisor/components/AlertDetail.tsx
+++ b/frontend/src/pages/supervisor/components/AlertDetail.tsx
@@ -13,6 +13,13 @@ import { AlertTriangle, CheckCircle, User, Clock } from 'lucide-react';
 import type { SupervisorAlertViewModel, SupervisorCallViewModel } from '@/lib/supervisor-alerts';
 
 const MIN_RELATED_CALLS_SKELETON_MS = 250;
+const RELATED_CALLS_CROSSFADE_MS = 650;
+const LOADED_RELATED_CALLS_CLASSNAME =
+  'space-y-3 animate-in fade-in-0 duration-700 ease-out';
+const CROSSFADE_SKELETON_CLASSNAME =
+  'space-y-3 animate-out fade-out-0 duration-500 ease-out';
+
+type LoadingTransitionPhase = 'loading' | 'crossfading' | 'loaded';
 
 export interface AlertDetailProps {
   alert: SupervisorAlertViewModel | null;
@@ -36,10 +43,13 @@ export function AlertDetail({
   severityClassName,
 }: AlertDetailProps) {
   const primaryCall = relatedCalls[0];
-  const showRelatedCallsSkeleton = useMinimumLoadingState(
+  const relatedCallsLoadingPhase = useLoadingTransitionPhase(
     isLoadingRelatedCalls,
-    MIN_RELATED_CALLS_SKELETON_MS
+    MIN_RELATED_CALLS_SKELETON_MS,
+    RELATED_CALLS_CROSSFADE_MS
   );
+  const showRelatedCallsSkeleton = relatedCallsLoadingPhase !== 'loaded';
+  const showRelatedCallsContent = relatedCallsLoadingPhase !== 'loading';
   const isRecurringAlert =
     alert?.type === 'recurring_topic' || alert?.type === 'recurring_keyword';
 
@@ -70,119 +80,60 @@ export function AlertDetail({
 
             {!isRecurringAlert && (showRelatedCallsSkeleton || primaryCall) && (
               <div className="p-4 bg-muted/50 rounded-lg space-y-3">
-                {showRelatedCallsSkeleton ? (
-                  <div
-                    className="space-y-3"
-                    role="status"
-                    aria-label="Loading call information"
-                  >
-                    <Skeleton className="h-4 w-28" />
-                    <div className="grid grid-cols-2 gap-3">
-                      <div className="flex items-center gap-2">
-                        <User className="h-4 w-4 text-muted-foreground" />
-                        <Skeleton className="h-4 w-24" />
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Clock className="h-4 w-4 text-muted-foreground" />
-                        <Skeleton className="h-4 w-16" />
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <Skeleton className="h-4 w-20" />
-                      <Skeleton className="h-6 w-16 rounded-full" />
-                    </div>
-                    <Skeleton className="h-9 w-full" />
+                {showRelatedCallsSkeleton && showRelatedCallsContent ? (
+                  <div className="grid">
+                    <CallInformationSkeleton
+                      className={`${CROSSFADE_SKELETON_CLASSNAME} col-start-1 row-start-1`}
+                      ariaHidden
+                    />
+                    {primaryCall ? (
+                      <CallInformationContent
+                        call={primaryCall}
+                        onOpenCall={onOpenCall}
+                        onClose={onClose}
+                        className={`${LOADED_RELATED_CALLS_CLASSNAME} col-start-1 row-start-1`}
+                      />
+                    ) : null}
                   </div>
+                ) : showRelatedCallsSkeleton ? (
+                  <CallInformationSkeleton />
                 ) : primaryCall ? (
-                  <>
-                    <h5 className="text-sm font-medium">Call Information</h5>
-                    <div className="grid grid-cols-2 gap-3 text-sm">
-                      <div className="flex items-center gap-2">
-                        <User className="h-4 w-4 text-muted-foreground" />
-                        {primaryCall.agentName}
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Clock className="h-4 w-4 text-muted-foreground" />
-                        {Math.floor(primaryCall.durationSec / 60)}m {primaryCall.durationSec % 60}s
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <span className="text-muted-foreground">Sentiment:</span>
-                      <SentimentBadge sentiment={primaryCall.sentimentLabel} />
-                    </div>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-full"
-                      onClick={() => {
-                        onOpenCall(primaryCall.id);
-                        onClose();
-                      }}
-                    >
-                      View Full Call Details
-                    </Button>
-                  </>
+                  <CallInformationContent
+                    call={primaryCall}
+                    onOpenCall={onOpenCall}
+                    onClose={onClose}
+                    className={LOADED_RELATED_CALLS_CLASSNAME}
+                  />
                 ) : null}
               </div>
             )}
 
             {isRecurringAlert && (
               <div className="p-4 bg-muted/50 rounded-lg space-y-3">
-                {showRelatedCallsSkeleton ? (
-                  <div
-                    className="space-y-3"
-                    role="status"
-                    aria-label="Loading affected calls"
-                  >
-                    <Skeleton className="h-4 w-32" />
-                    <div className="space-y-2">
-                      {Array.from({ length: 3 }).map((_, index) => (
-                        <div
-                          key={index}
-                          className="flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3"
-                        >
-                          <Skeleton className="h-4 w-36" />
-                          <Skeleton className="h-6 w-16 rounded-full" />
-                        </div>
-                      ))}
-                    </div>
+                {showRelatedCallsSkeleton && showRelatedCallsContent ? (
+                  <div className="grid">
+                    <AffectedCallsSkeleton
+                      className={`${CROSSFADE_SKELETON_CLASSNAME} col-start-1 row-start-1`}
+                      ariaHidden
+                    />
+                    <AffectedCallsContent
+                      alert={alert}
+                      relatedCalls={relatedCalls}
+                      onOpenCall={onOpenCall}
+                      onClose={onClose}
+                      className={`${LOADED_RELATED_CALLS_CLASSNAME} col-start-1 row-start-1`}
+                    />
                   </div>
-                ) : relatedCalls.length > 0 ? (
-                  <>
-                    <h5 className="text-sm font-medium">
-                      Affected Calls
-                      {alert?.matchedCount ? ` (${alert.matchedCount})` : ''}
-                    </h5>
-                    <div className="space-y-2">
-                      {relatedCalls.map((call) => (
-                        <Button
-                          key={call.id}
-                          variant="outline"
-                          size="sm"
-                          className="w-full justify-between"
-                          onClick={() => {
-                            onOpenCall(call.id);
-                            onClose();
-                          }}
-                        >
-                          <span className="truncate text-left">
-                            {call.agentName} · {new Date(call.startedAt).toLocaleDateString()}
-                          </span>
-                          <SentimentBadge sentiment={call.sentimentLabel} />
-                        </Button>
-                      ))}
-                    </div>
-                  </>
+                ) : showRelatedCallsSkeleton ? (
+                  <AffectedCallsSkeleton />
                 ) : (
-                  <>
-                    <h5 className="text-sm font-medium">
-                      Affected Calls
-                      {alert?.matchedCount ? ` (${alert.matchedCount})` : ''}
-                    </h5>
-                    <p className="text-sm text-muted-foreground">
-                      No contributing calls were found for this recurring alert.
-                    </p>
-                  </>
+                  <AffectedCallsContent
+                    alert={alert}
+                    relatedCalls={relatedCalls}
+                    onOpenCall={onOpenCall}
+                    onClose={onClose}
+                    className={LOADED_RELATED_CALLS_CLASSNAME}
+                  />
                 )}
               </div>
             )}
@@ -213,21 +164,194 @@ export function AlertDetail({
   );
 }
 
-function useMinimumLoadingState(isLoading: boolean, minimumMs: number) {
-  const [showLoading, setShowLoading] = useState(isLoading);
+function CallInformationSkeleton({
+  className = 'space-y-3',
+  ariaHidden = false,
+}: {
+  className?: string;
+  ariaHidden?: boolean;
+}) {
+  return (
+    <div
+      className={className}
+      role={ariaHidden ? undefined : 'status'}
+      aria-label={ariaHidden ? undefined : 'Loading call information'}
+      aria-hidden={ariaHidden || undefined}
+    >
+      <Skeleton className="h-4 w-28" />
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex items-center gap-2">
+          <User className="h-4 w-4 text-muted-foreground" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Clock className="h-4 w-4 text-muted-foreground" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-4 w-20" />
+        <Skeleton className="h-6 w-16 rounded-full" />
+      </div>
+      <Skeleton className="h-9 w-full" />
+    </div>
+  );
+}
+
+function CallInformationContent({
+  call,
+  onOpenCall,
+  onClose,
+  className,
+}: {
+  call: SupervisorCallViewModel;
+  onOpenCall: (callId: string) => void;
+  onClose: () => void;
+  className: string;
+}) {
+  return (
+    <div className={className}>
+      <h5 className="text-sm font-medium">Call Information</h5>
+      <div className="grid grid-cols-2 gap-3 text-sm">
+        <div className="flex items-center gap-2">
+          <User className="h-4 w-4 text-muted-foreground" />
+          {call.agentName}
+        </div>
+        <div className="flex items-center gap-2">
+          <Clock className="h-4 w-4 text-muted-foreground" />
+          {Math.floor(call.durationSec / 60)}m {call.durationSec % 60}s
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <span className="text-muted-foreground">Sentiment:</span>
+        <SentimentBadge sentiment={call.sentimentLabel} />
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        className="w-full"
+        onClick={() => {
+          onOpenCall(call.id);
+          onClose();
+        }}
+      >
+        View Full Call Details
+      </Button>
+    </div>
+  );
+}
+
+function AffectedCallsSkeleton({
+  className = 'space-y-3',
+  ariaHidden = false,
+}: {
+  className?: string;
+  ariaHidden?: boolean;
+}) {
+  return (
+    <div
+      className={className}
+      role={ariaHidden ? undefined : 'status'}
+      aria-label={ariaHidden ? undefined : 'Loading affected calls'}
+      aria-hidden={ariaHidden || undefined}
+    >
+      <Skeleton className="h-4 w-32" />
+      <div className="space-y-2">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div
+            key={index}
+            className="flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3"
+          >
+            <Skeleton className="h-4 w-36" />
+            <Skeleton className="h-6 w-16 rounded-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AffectedCallsContent({
+  alert,
+  relatedCalls,
+  onOpenCall,
+  onClose,
+  className,
+}: {
+  alert: SupervisorAlertViewModel;
+  relatedCalls: SupervisorCallViewModel[];
+  onOpenCall: (callId: string) => void;
+  onClose: () => void;
+  className: string;
+}) {
+  return (
+    <div className={className}>
+      <h5 className="text-sm font-medium">
+        Affected Calls
+        {alert.matchedCount ? ` (${alert.matchedCount})` : ''}
+      </h5>
+      {relatedCalls.length > 0 ? (
+        <div className="space-y-2">
+          {relatedCalls.map((call) => (
+            <Button
+              key={call.id}
+              variant="outline"
+              size="sm"
+              className="w-full justify-between"
+              onClick={() => {
+                onOpenCall(call.id);
+                onClose();
+              }}
+            >
+              <span className="truncate text-left">
+                {call.agentName} · {new Date(call.startedAt).toLocaleDateString()}
+              </span>
+              <SentimentBadge sentiment={call.sentimentLabel} />
+            </Button>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          No contributing calls were found for this recurring alert.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function useLoadingTransitionPhase(
+  isLoading: boolean,
+  minimumMs: number,
+  crossfadeMs: number
+) {
+  const [phase, setPhase] = useState<LoadingTransitionPhase>(
+    isLoading ? 'loading' : 'loaded'
+  );
 
   useEffect(() => {
     if (isLoading) {
-      setShowLoading(true);
+      setPhase('loading');
       return undefined;
     }
 
-    const timeout = window.setTimeout(() => {
-      setShowLoading(false);
+    if (phase === 'loaded') {
+      return undefined;
+    }
+
+    if (phase === 'crossfading') {
+      const crossfadeTimeout = window.setTimeout(() => {
+        setPhase('loaded');
+      }, crossfadeMs);
+
+      return () => window.clearTimeout(crossfadeTimeout);
+    }
+
+    const minimumTimeout = window.setTimeout(() => {
+      setPhase('crossfading');
     }, minimumMs);
 
-    return () => window.clearTimeout(timeout);
-  }, [isLoading, minimumMs]);
+    return () => window.clearTimeout(minimumTimeout);
+  }, [crossfadeMs, isLoading, minimumMs, phase]);
 
-  return showLoading;
+  return phase;
 }

--- a/frontend/src/pages/supervisor/components/AlertDetail.tsx
+++ b/frontend/src/pages/supervisor/components/AlertDetail.tsx
@@ -63,13 +63,13 @@ export function AlertDetail({
 
             {!isRecurringAlert && (isLoadingRelatedCalls || primaryCall) && (
               <div className="p-4 bg-muted/50 rounded-lg space-y-3">
-                <h5 className="text-sm font-medium">Call Information</h5>
                 {isLoadingRelatedCalls ? (
                   <div
                     className="space-y-3"
                     role="status"
                     aria-label="Loading call information"
                   >
+                    <Skeleton className="h-4 w-28" />
                     <div className="grid grid-cols-2 gap-3">
                       <div className="flex items-center gap-2">
                         <User className="h-4 w-4 text-muted-foreground" />
@@ -88,6 +88,7 @@ export function AlertDetail({
                   </div>
                 ) : primaryCall ? (
                   <>
+                    <h5 className="text-sm font-medium">Call Information</h5>
                     <div className="grid grid-cols-2 gap-3 text-sm">
                       <div className="flex items-center gap-2">
                         <User className="h-4 w-4 text-muted-foreground" />
@@ -120,50 +121,61 @@ export function AlertDetail({
 
             {isRecurringAlert && (
               <div className="p-4 bg-muted/50 rounded-lg space-y-3">
-                <h5 className="text-sm font-medium">
-                  Affected Calls
-                  {alert?.matchedCount ? ` (${alert.matchedCount})` : ''}
-                </h5>
                 {isLoadingRelatedCalls ? (
                   <div
-                    className="space-y-2"
+                    className="space-y-3"
                     role="status"
                     aria-label="Loading affected calls"
                   >
-                    {Array.from({ length: 3 }).map((_, index) => (
-                      <div
-                        key={index}
-                        className="flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3"
-                      >
-                        <Skeleton className="h-4 w-36" />
-                        <Skeleton className="h-6 w-16 rounded-full" />
-                      </div>
-                    ))}
+                    <Skeleton className="h-4 w-32" />
+                    <div className="space-y-2">
+                      {Array.from({ length: 3 }).map((_, index) => (
+                        <div
+                          key={index}
+                          className="flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3"
+                        >
+                          <Skeleton className="h-4 w-36" />
+                          <Skeleton className="h-6 w-16 rounded-full" />
+                        </div>
+                      ))}
+                    </div>
                   </div>
                 ) : relatedCalls.length > 0 ? (
-                  <div className="space-y-2">
-                    {relatedCalls.map((call) => (
-                      <Button
-                        key={call.id}
-                        variant="outline"
-                        size="sm"
-                        className="w-full justify-between"
-                        onClick={() => {
-                          onOpenCall(call.id);
-                          onClose();
-                        }}
-                      >
-                        <span className="truncate text-left">
-                          {call.agentName} · {new Date(call.startedAt).toLocaleDateString()}
-                        </span>
-                        <SentimentBadge sentiment={call.sentimentLabel} />
-                      </Button>
-                    ))}
-                  </div>
+                  <>
+                    <h5 className="text-sm font-medium">
+                      Affected Calls
+                      {alert?.matchedCount ? ` (${alert.matchedCount})` : ''}
+                    </h5>
+                    <div className="space-y-2">
+                      {relatedCalls.map((call) => (
+                        <Button
+                          key={call.id}
+                          variant="outline"
+                          size="sm"
+                          className="w-full justify-between"
+                          onClick={() => {
+                            onOpenCall(call.id);
+                            onClose();
+                          }}
+                        >
+                          <span className="truncate text-left">
+                            {call.agentName} · {new Date(call.startedAt).toLocaleDateString()}
+                          </span>
+                          <SentimentBadge sentiment={call.sentimentLabel} />
+                        </Button>
+                      ))}
+                    </div>
+                  </>
                 ) : (
-                  <p className="text-sm text-muted-foreground">
-                    No contributing calls were found for this recurring alert.
-                  </p>
+                  <>
+                    <h5 className="text-sm font-medium">
+                      Affected Calls
+                      {alert?.matchedCount ? ` (${alert.matchedCount})` : ''}
+                    </h5>
+                    <p className="text-sm text-muted-foreground">
+                      No contributing calls were found for this recurring alert.
+                    </p>
+                  </>
                 )}
               </div>
             )}

--- a/frontend/src/pages/supervisor/components/AlertDetail.tsx
+++ b/frontend/src/pages/supervisor/components/AlertDetail.tsx
@@ -15,9 +15,9 @@ import type { SupervisorAlertViewModel, SupervisorCallViewModel } from '@/lib/su
 const MIN_RELATED_CALLS_SKELETON_MS = 250;
 const RELATED_CALLS_CROSSFADE_MS = 650;
 const LOADED_RELATED_CALLS_CLASSNAME =
-  'space-y-3 animate-in fade-in-0 duration-700 ease-out';
+  'space-y-3 col-start-1 row-start-1 animate-in fade-in-0 duration-700 ease-out';
 const CROSSFADE_SKELETON_CLASSNAME =
-  'space-y-3 animate-out fade-out-0 duration-500 ease-out';
+  'space-y-3 col-start-1 row-start-1 animate-out fade-out-0 duration-500 ease-out';
 
 type LoadingTransitionPhase = 'loading' | 'crossfading' | 'loaded';
 
@@ -50,6 +50,7 @@ export function AlertDetail({
   );
   const showRelatedCallsSkeleton = relatedCallsLoadingPhase !== 'loaded';
   const showRelatedCallsContent = relatedCallsLoadingPhase !== 'loading';
+  const isCrossfadingRelatedCalls = relatedCallsLoadingPhase === 'crossfading';
   const isRecurringAlert =
     alert?.type === 'recurring_topic' || alert?.type === 'recurring_keyword';
 
@@ -80,61 +81,56 @@ export function AlertDetail({
 
             {!isRecurringAlert && (showRelatedCallsSkeleton || primaryCall) && (
               <div className="p-4 bg-muted/50 rounded-lg space-y-3">
-                {showRelatedCallsSkeleton && showRelatedCallsContent ? (
-                  <div className="grid">
+                <div className="grid">
+                  {showRelatedCallsSkeleton ? (
                     <CallInformationSkeleton
-                      className={`${CROSSFADE_SKELETON_CLASSNAME} col-start-1 row-start-1`}
-                      ariaHidden
+                      key="call-information-skeleton"
+                      className={
+                        isCrossfadingRelatedCalls
+                          ? CROSSFADE_SKELETON_CLASSNAME
+                          : undefined
+                      }
+                      ariaHidden={showRelatedCallsContent}
                     />
-                    {primaryCall ? (
-                      <CallInformationContent
-                        call={primaryCall}
-                        onOpenCall={onOpenCall}
-                        onClose={onClose}
-                        className={`${LOADED_RELATED_CALLS_CLASSNAME} col-start-1 row-start-1`}
-                      />
-                    ) : null}
-                  </div>
-                ) : showRelatedCallsSkeleton ? (
-                  <CallInformationSkeleton />
-                ) : primaryCall ? (
-                  <CallInformationContent
-                    call={primaryCall}
-                    onOpenCall={onOpenCall}
-                    onClose={onClose}
-                    className={LOADED_RELATED_CALLS_CLASSNAME}
-                  />
-                ) : null}
+                  ) : null}
+                  {showRelatedCallsContent && primaryCall ? (
+                    <CallInformationContent
+                      key="call-information-content"
+                      call={primaryCall}
+                      onOpenCall={onOpenCall}
+                      onClose={onClose}
+                      className={LOADED_RELATED_CALLS_CLASSNAME}
+                    />
+                  ) : null}
+                </div>
               </div>
             )}
 
             {isRecurringAlert && (
               <div className="p-4 bg-muted/50 rounded-lg space-y-3">
-                {showRelatedCallsSkeleton && showRelatedCallsContent ? (
-                  <div className="grid">
+                <div className="grid">
+                  {showRelatedCallsSkeleton ? (
                     <AffectedCallsSkeleton
-                      className={`${CROSSFADE_SKELETON_CLASSNAME} col-start-1 row-start-1`}
-                      ariaHidden
+                      key="affected-calls-skeleton"
+                      className={
+                        isCrossfadingRelatedCalls
+                          ? CROSSFADE_SKELETON_CLASSNAME
+                          : undefined
+                      }
+                      ariaHidden={showRelatedCallsContent}
                     />
+                  ) : null}
+                  {showRelatedCallsContent ? (
                     <AffectedCallsContent
+                      key="affected-calls-content"
                       alert={alert}
                       relatedCalls={relatedCalls}
                       onOpenCall={onOpenCall}
                       onClose={onClose}
-                      className={`${LOADED_RELATED_CALLS_CLASSNAME} col-start-1 row-start-1`}
+                      className={LOADED_RELATED_CALLS_CLASSNAME}
                     />
-                  </div>
-                ) : showRelatedCallsSkeleton ? (
-                  <AffectedCallsSkeleton />
-                ) : (
-                  <AffectedCallsContent
-                    alert={alert}
-                    relatedCalls={relatedCalls}
-                    onOpenCall={onOpenCall}
-                    onClose={onClose}
-                    className={LOADED_RELATED_CALLS_CLASSNAME}
-                  />
-                )}
+                  ) : null}
+                </div>
               </div>
             )}
 
@@ -165,7 +161,7 @@ export function AlertDetail({
 }
 
 function CallInformationSkeleton({
-  className = 'space-y-3',
+  className = 'space-y-3 col-start-1 row-start-1',
   ariaHidden = false,
 }: {
   className?: string;
@@ -242,7 +238,7 @@ function CallInformationContent({
 }
 
 function AffectedCallsSkeleton({
-  className = 'space-y-3',
+  className = 'space-y-3 col-start-1 row-start-1',
   ariaHidden = false,
 }: {
   className?: string;

--- a/frontend/src/pages/supervisor/components/SearchResults.tsx
+++ b/frontend/src/pages/supervisor/components/SearchResults.tsx
@@ -31,6 +31,21 @@ function sentimentAccentClass(sentiment: Call['sentimentLabel']) {
   }
 }
 
+function formatResultsSummary(results: SearchResult): string {
+  const { total, page, pageSize, totalPages, calls } = results;
+  if (total === 0) {
+    return 'Found 0 calls';
+  }
+  if (calls.length === 0) {
+    return `${total} calls found · Page ${page} of ${totalPages}`;
+  }
+  const start = (page - 1) * pageSize + 1;
+  const end = (page - 1) * pageSize + calls.length;
+  const range =
+    start === end ? `Showing ${start} of ${total}` : `Showing ${start}–${end} of ${total}`;
+  return `${range} calls · Page ${page} of ${totalPages}`;
+}
+
 function SearchResultSkeleton() {
   return (
     <Card className="p-4 border-l-4 border-l-muted">
@@ -79,7 +94,7 @@ export function SearchResults({
     <div className="space-y-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-sm text-muted-foreground">
-          Found {results.total} calls (page {results.page} of {results.totalPages})
+          {formatResultsSummary(results)}
         </p>
         {results.totalPages > 1 && (
           <div className="flex gap-2">

--- a/frontend/src/pages/supervisor/components/__tests__/AlertDetail.test.tsx
+++ b/frontend/src/pages/supervisor/components/__tests__/AlertDetail.test.tsx
@@ -3,23 +3,33 @@ import { render, screen } from '@testing-library/react';
 import { AlertDetail } from '../AlertDetail';
 
 describe('AlertDetail', () => {
+  const baseAlert = {
+    id: 'alert-1',
+    type: 'recurring_keyword' as const,
+    callId: null,
+    createdAt: '2026-04-02T12:00:00Z',
+    ruleId: 'rule-1',
+    ruleLabel: 'Recurring keyword detected',
+    severity: 'high' as const,
+    status: 'open' as const,
+    issue: 'Keyword "refund" appeared across multiple calls.',
+    matchedValue: 'refund',
+    matchedCount: 2,
+    windowDays: 7,
+  };
+
+  const baseProps = {
+    onClose: vi.fn(),
+    onOpenCall: vi.fn(),
+    onCloseAlert: vi.fn(),
+    onReopenAlert: vi.fn(),
+    severityClassName: () => 'severity',
+  };
+
   it('renders affected calls for recurring alerts', () => {
     render(
       <AlertDetail
-        alert={{
-          id: 'alert-1',
-          type: 'recurring_keyword',
-          callId: null,
-          createdAt: '2026-04-02T12:00:00Z',
-          ruleId: 'rule-1',
-          ruleLabel: 'Recurring keyword detected',
-          severity: 'high',
-          status: 'open',
-          issue: 'Keyword "refund" appeared across multiple calls.',
-          matchedValue: 'refund',
-          matchedCount: 2,
-          windowDays: 7,
-        }}
+        alert={baseAlert}
         relatedCalls={[
           {
             id: 'call-1',
@@ -52,16 +62,48 @@ describe('AlertDetail', () => {
             openAlertId: null,
           },
         ]}
-        onClose={vi.fn()}
-        onOpenCall={vi.fn()}
-        onCloseAlert={vi.fn()}
-        onReopenAlert={vi.fn()}
-        severityClassName={() => 'severity'}
+        {...baseProps}
       />
     );
 
     expect(screen.getByText('Affected Calls (2)')).toBeInTheDocument();
     expect(screen.getByText(/Ada Lovelace/)).toBeInTheDocument();
     expect(screen.getByText(/Grace Hopper/)).toBeInTheDocument();
+  });
+
+  it('renders a skeleton while recurring alert calls load', () => {
+    render(
+      <AlertDetail
+        alert={baseAlert}
+        relatedCalls={[]}
+        isLoadingRelatedCalls
+        {...baseProps}
+      />
+    );
+
+    expect(screen.getByRole('status', { name: 'Loading affected calls' })).toBeInTheDocument();
+    expect(screen.queryByText('Loading related calls...')).not.toBeInTheDocument();
+  });
+
+  it('renders a skeleton while single alert call information loads', () => {
+    render(
+      <AlertDetail
+        alert={{
+          ...baseAlert,
+          type: 'sentiment_threshold',
+          callId: 'call-1',
+          ruleLabel: 'Negative sentiment threshold breached',
+          issue: 'Call sentiment score fell below the configured threshold.',
+          matchedCount: null,
+          windowDays: null,
+        }}
+        relatedCalls={[]}
+        isLoadingRelatedCalls
+        {...baseProps}
+      />
+    );
+
+    expect(screen.getByText('Call Information')).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Loading call information' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/supervisor/components/__tests__/AlertDetail.test.tsx
+++ b/frontend/src/pages/supervisor/components/__tests__/AlertDetail.test.tsx
@@ -1,8 +1,12 @@
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
 import { AlertDetail } from '../AlertDetail';
 
 describe('AlertDetail', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   const baseAlert = {
     id: 'alert-1',
     type: 'recurring_keyword' as const,
@@ -26,26 +30,28 @@ describe('AlertDetail', () => {
     severityClassName: () => 'severity',
   };
 
+  const baseCall = {
+    id: 'call-1',
+    agentId: 'agent-1',
+    agentName: 'Ada Lovelace',
+    startedAt: '2026-04-02T12:00:00Z',
+    durationSec: 240,
+    sentimentScore: -0.3,
+    sentimentLabel: 'negative' as const,
+    topics: ['refund'],
+    resolved: false,
+    csat: null,
+    customerName: 'Customer',
+    hasOpenAlert: false,
+    openAlertId: null,
+  };
+
   it('renders affected calls for recurring alerts', () => {
     render(
       <AlertDetail
         alert={baseAlert}
         relatedCalls={[
-          {
-            id: 'call-1',
-            agentId: 'agent-1',
-            agentName: 'Ada Lovelace',
-            startedAt: '2026-04-02T12:00:00Z',
-            durationSec: 240,
-            sentimentScore: -0.3,
-            sentimentLabel: 'negative',
-            topics: ['refund'],
-            resolved: false,
-            csat: null,
-            customerName: 'Customer',
-            hasOpenAlert: false,
-            openAlertId: null,
-          },
+          baseCall,
           {
             id: 'call-2',
             agentId: 'agent-2',
@@ -106,5 +112,36 @@ describe('AlertDetail', () => {
 
     expect(screen.getByRole('status', { name: 'Loading call information' })).toBeInTheDocument();
     expect(screen.queryByText('Call Information')).not.toBeInTheDocument();
+  });
+
+  it('keeps the skeleton visible briefly after calls finish loading', () => {
+    vi.useFakeTimers();
+
+    const { rerender } = render(
+      <AlertDetail
+        alert={baseAlert}
+        relatedCalls={[]}
+        isLoadingRelatedCalls
+        {...baseProps}
+      />
+    );
+
+    rerender(
+      <AlertDetail
+        alert={baseAlert}
+        relatedCalls={[baseCall]}
+        isLoadingRelatedCalls={false}
+        {...baseProps}
+      />
+    );
+
+    expect(screen.getByRole('status', { name: 'Loading affected calls' })).toBeInTheDocument();
+    expect(screen.queryByText('Affected Calls (2)')).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(250);
+    });
+
+    expect(screen.getByText('Affected Calls (2)')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/supervisor/components/__tests__/AlertDetail.test.tsx
+++ b/frontend/src/pages/supervisor/components/__tests__/AlertDetail.test.tsx
@@ -82,6 +82,7 @@ describe('AlertDetail', () => {
     );
 
     expect(screen.getByRole('status', { name: 'Loading affected calls' })).toBeInTheDocument();
+    expect(screen.queryByText('Affected Calls (2)')).not.toBeInTheDocument();
     expect(screen.queryByText('Loading related calls...')).not.toBeInTheDocument();
   });
 
@@ -103,7 +104,7 @@ describe('AlertDetail', () => {
       />
     );
 
-    expect(screen.getByText('Call Information')).toBeInTheDocument();
     expect(screen.getByRole('status', { name: 'Loading call information' })).toBeInTheDocument();
+    expect(screen.queryByText('Call Information')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
This PR improves the supervisor alert experience by making alert call details feel smoother while data is loading, especially for recurring alerts and single-call alerts. It also includes a small pagination fix so alert navigation behaves more reliably.

## Changes
- Added skeleton loading states for single-call alert details
- Added skeleton loading states for recurring alert affected-call lists
- Hid "Call Information" and "Affected Calls" headings until their call data is ready
- Added a short minimum skeleton duration to avoid quick loading flashes
- Added a shimmer-to-result crossfade transition for loaded alert call content
- Fixed a pagination bug

## Testing
- `npm test -- AlertDetail.test.tsx`
- `npm run typecheck`
- `npm run lint` passes with existing warnings only
