### PR TITLE
Lab-2 refactor

### DIFF
--- a/backend/services/alerts.py
+++ b/backend/services/alerts.py
@@ -30,7 +30,13 @@ def _normalize_values(values: list[str] | dict[str, bool] | None) -> set[str]:
 
 
 def _parse_iso_datetime(value: str) -> datetime:
-    """Parse ISO timestamps that may include a trailing Z."""
+    """Parse ISO timestamps that may include a trailing Z.
+
+    Raises:
+        ValueError: If value is empty or blank.
+    """
+    if not value or not value.strip():
+        raise ValueError(f"Cannot parse timestamp: expected a non-empty ISO string, got {value!r}")
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 

--- a/backend/tests/test_alert_service.py
+++ b/backend/tests/test_alert_service.py
@@ -6,6 +6,25 @@ import pytest
 
 from database.constants import AlertRuleType
 from services import alerts as alert_service
+from services.alerts import _parse_iso_datetime
+
+
+def test_parse_iso_datetime_handles_z_suffix() -> None:
+    """_parse_iso_datetime should normalise the Z suffix to +00:00."""
+    dt = _parse_iso_datetime("2026-04-02T12:00:00Z")
+    assert dt.isoformat() == "2026-04-02T12:00:00+00:00"
+
+
+def test_parse_iso_datetime_raises_on_empty_string() -> None:
+    """_parse_iso_datetime should raise ValueError for empty input, not a cryptic internal error."""
+    with pytest.raises(ValueError, match="Cannot parse timestamp"):
+        _parse_iso_datetime("")
+
+
+def test_parse_iso_datetime_raises_on_blank_string() -> None:
+    """_parse_iso_datetime should raise ValueError for whitespace-only input."""
+    with pytest.raises(ValueError, match="Cannot parse timestamp"):
+        _parse_iso_datetime("   ")
 
 
 def test_evaluate_alert_rules_triggers_sentiment_rule(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Overview

This report documents the VIBE (Verify → Improve → Build → Execute) refactor of a single, isolated backend utility function in the AWS Connect Insight project. The goal was to demonstrate controlled, human-verified AI-assisted refactoring without introducing new errors or architectural risk.

---

## Step 1 – Target Selection

**Target:** `_parse_iso_datetime` — `backend/services/alerts.py`, line 32

**What it does:**
A private helper that converts raw ISO 8601 timestamp strings from the database (which may carry a trailing `Z` for UTC) into Python `datetime` objects. It is called by `_window_start`, which computes the lookback window for recurring alert rule evaluation.

**Why it was low-risk:**

| Criterion | Evidence |
|---|---|
| Isolated | Private function (`_` prefix), called in exactly one place within the same file |
| Well-defined I/O | Input: `str`, Output: `datetime` — no side effects, no DB or network calls |
| In need of care | No input guard — passing an empty string caused a cryptic internal `ValueError` from `datetime.fromisoformat` with no useful message for the caller |

**Original code (before refactor):**

```python
# backend/services/alerts.py  –  lines 32–34
def _parse_iso_datetime(value: str) -> datetime:
    """Parse ISO timestamps that may include a trailing Z."""
    return datetime.fromisoformat(value.replace("Z", "+00:00"))
```

**Why it was flagged in the Module 1 inventory:**
The function silently trusted that callers would never pass blank or `None`-coerced strings. The alert evaluation pipeline pulls timestamps from database rows; a missing `started_at` value could produce an empty string that would bubble up as an unreadable `ValueError: Invalid isoformat string: ''` with no context about which field failed or why.

---

## Step 2 – The VIBE Execution Protocol

### V — Verify (The Audit)

**AI suggestion (Cursor):**

The AI proposed updating the function to use Python's native `datetime.fromisoformat` without the `.replace()` call, since Python 3.11+ handles the `Z` suffix natively:

```python
# AI-generated suggestion
def _parse_iso_datetime(value: str) -> datetime:
    """Parse ISO timestamps that may include a trailing Z."""
    return datetime.fromisoformat(value)  # Python 3.11+ handles Z natively
```

**The Audit — What I rejected and why:**

I rejected the AI's simplification. While technically correct for Python 3.11+, this change would silently break any environment running Python 3.10 or earlier, where `datetime.fromisoformat("2026-04-02T12:00:00Z")` raises a `ValueError`. Confirming the runtime Python version is `3.13.2` (visible in the test output) is not sufficient justification to remove the `.replace()` — the explicit conversion is cheap, universally compatible, and self-documenting. The generic AI suggestion did not account for the project's cross-version deployment context.

**Final implementation — kept `.replace()`, added the defensive guard instead:**

```python
def _parse_iso_datetime(value: str) -> datetime:
    """Parse ISO timestamps that may include a trailing Z.

    Raises:
        ValueError: If value is empty or blank.
    """
    if not value or not value.strip():
        raise ValueError(f"Cannot parse timestamp: expected a non-empty ISO string, got {value!r}")
    return datetime.fromisoformat(value.replace("Z", "+00:00"))
```

---

### I — Improve

**What was added:**

1. **Explicit input guard** — rejects empty and whitespace-only strings with a human-readable error message that names the bad input (`got ''`), making debugging straightforward.
2. **Docstring `Raises` block** — documents the contract so callers know what to expect, replacing the implicit assumption that input is always valid.

The improvement adds **type safety at the boundary** without changing the function's behaviour for any currently valid input. No existing call site passes a blank string today, so the guard is purely defensive — it does not alter the live execution path.

---

### B — Build

**Integration:** No imports added, no interface changed. The function remains private; its single call site (`_window_start`) passes a value already guarded upstream by the database layer.

**Build check:**

```
$ cd backend && python -m pytest tests/test_alert_service.py -v
```

Output (see Evidence of Execution below):

```
13 passed in 0.39s
```

Zero warnings. All 10 pre-existing tests continue to pass unchanged.

**Clean Code compliance (Module 1 standards):**

| Standard | Met? |
|---|---|
| Single responsibility | Yes — function still does exactly one thing |
| Descriptive error message | Yes — message names the bad input |
| No dead code introduced | Yes |
| No magic values | Yes — `value!r` uses repr for safe quoting |
| Docstring updated | Yes — `Raises` block added |

---

### E — Execute

**Three new tests added to `backend/tests/test_alert_service.py`:**

```python
def test_parse_iso_datetime_handles_z_suffix() -> None:
    """_parse_iso_datetime should normalise the Z suffix to +00:00."""
    dt = _parse_iso_datetime("2026-04-02T12:00:00Z")
    assert dt.isoformat() == "2026-04-02T12:00:00+00:00"


def test_parse_iso_datetime_raises_on_empty_string() -> None:
    """_parse_iso_datetime should raise ValueError for empty input, not a cryptic internal error."""
    with pytest.raises(ValueError, match="Cannot parse timestamp"):
        _parse_iso_datetime("")


def test_parse_iso_datetime_raises_on_blank_string() -> None:
    """_parse_iso_datetime should raise ValueError for whitespace-only input."""
    with pytest.raises(ValueError, match="Cannot parse timestamp"):
        _parse_iso_datetime("   ")
```

**Evidence of Execution — full test run output:**

```
============================= test session starts ==============================
platform darwin -- Python 3.13.2, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/mujeeb/development/aws-connect-insight/backend
configfile: pyproject.toml

tests/test_alert_service.py::test_parse_iso_datetime_handles_z_suffix        PASSED [  7%]
tests/test_alert_service.py::test_parse_iso_datetime_raises_on_empty_string  PASSED [ 15%]
tests/test_alert_service.py::test_parse_iso_datetime_raises_on_blank_string  PASSED [ 23%]
tests/test_alert_service.py::test_evaluate_alert_rules_triggers_sentiment_rule           PASSED [ 30%]
tests/test_alert_service.py::test_evaluate_alert_rules_skips_non_matching_keyword_rule   PASSED [ 38%]
tests/test_alert_service.py::test_evaluate_alert_rules_normalizes_keyword_matches        PASSED [ 46%]
tests/test_alert_service.py::test_evaluate_alert_rules_triggers_recurring_topic          PASSED [ 53%]
tests/test_alert_service.py::test_evaluate_alert_rules_updates_existing_open_recurring_alert      PASSED [ 61%]
tests/test_alert_service.py::test_evaluate_alert_rules_retriggers_closed_recurring_alert_as_new   PASSED [ 69%]
tests/test_alert_service.py::test_evaluate_alert_rules_requests_only_active_rules        PASSED [ 76%]
tests/test_alert_service.py::test_get_related_call_ids_for_alert_returns_single_call_for_manual_alert              PASSED [ 84%]
tests/test_alert_service.py::test_get_related_call_ids_for_alert_filters_recurring_topic_matches   PASSED [ 92%]
tests/test_alert_service.py::test_get_related_call_ids_for_alert_filters_recurring_keyword_matches PASSED [100%]

============================== 13 passed in 0.39s ==============================
```

**13 of 13 tests passed. 0 failures. 0 warnings.**

---

## Step 3 – The PR Description (VIBE Report Template)

> Copy-paste this directly into the GitHub Pull Request description.

---

### 🛡️ VIBE Report

**1. Target Selected:**
`_parse_iso_datetime` in `backend/services/alerts.py` — a private, single-responsibility utility that parses ISO timestamp strings for alert window calculations. It was selected as the low-risk candidate because it is isolated (private, one call site), has a fully typed and predictable interface (`str → datetime`), and carried a silent failure mode that was flagged during the Module 1 inventory.

**2. The Verification Event:**
The AI (Cursor) suggested removing the `.replace("Z", "+00:00")` call because Python 3.11+ handles `Z` natively:

```python
# AI suggestion
return datetime.fromisoformat(value)
```

I rejected this. The `.replace()` pattern works across all Python versions and is self-documenting about the edge case it handles. The AI's suggestion optimised for a specific runtime version without confirming cross-environment compatibility. Instead, I kept `.replace()` and added the missing input guard that the AI did not flag at all:

```python
# Final implementation
if not value or not value.strip():
    raise ValueError(f"Cannot parse timestamp: expected a non-empty ISO string, got {value!r}")
return datetime.fromisoformat(value.replace("Z", "+00:00"))
```

**3. Trust Boundary Established:**
Before this refactor, an empty or whitespace-only timestamp string (possible when a database row has a `NULL` `started_at` coerced to `""` by the serialisation layer) would propagate as `ValueError: Invalid isoformat string: ''` — a Python-internal message with no indication of which field failed or from which pipeline stage. After this refactor, the failure is caught immediately at the parsing boundary with a message that names the bad value, making the root cause diagnosable in a single log line. Three new tests lock in both the valid-input behaviour and the two invalid-input branches.

**Evidence of Execution:**

```
13 passed in 0.39s  ←  0 regressions, 3 new tests green
```

*(Full test log included in VIBE_REPORT.md)*

---

## Files Changed

| File | Change |
|---|---|
| `backend/services/alerts.py` | Added input guard + `Raises` docstring to `_parse_iso_datetime` |
| `backend/tests/test_alert_service.py` | Added 3 targeted tests for the refactored function |
| `VIBE_REPORT.md` | This submission document |
