### PR TITLE
extract export utilities

### DIFF
--- a/frontend/src/lib/export/csv.ts
+++ b/frontend/src/lib/export/csv.ts
@@ -1,0 +1,27 @@
+export function exportCSV(data: Record<string, unknown>[], filename: string) {
+  if (data.length === 0) return;
+
+  const headers = Object.keys(data[0]);
+  const csvContent = [
+    headers.join(','),
+    ...data.map((row) =>
+      headers
+        .map((h) => {
+          const val = row[h];
+          if (typeof val === 'string' && (val.includes(',') || val.includes('"'))) {
+            return `"${val.replace(/"/g, '""')}"`;
+          }
+          return val;
+        })
+        .join(',')
+    ),
+  ].join('\n');
+
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${filename}.csv`;
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/lib/export/email.ts
+++ b/frontend/src/lib/export/email.ts
@@ -1,0 +1,6 @@
+import { useAppStore } from '@/stores/app-store';
+
+export function sendEmailMock(to: string, subject: string, body: string) {
+  useAppStore.getState().addSentEmail({ to, subject, body });
+  return { success: true, message: `Email queued to ${to}` };
+}

--- a/frontend/src/lib/export/index.ts
+++ b/frontend/src/lib/export/index.ts
@@ -1,0 +1,3 @@
+export { exportCSV } from './csv';
+export { exportPDF, exportPDFText } from './pdf';
+export { sendEmailMock } from './email';

--- a/frontend/src/lib/export/pdf.ts
+++ b/frontend/src/lib/export/pdf.ts
@@ -1,0 +1,73 @@
+import jsPDF from 'jspdf';
+import html2canvas from 'html2canvas';
+
+export async function exportPDF(elementId: string, filename: string): Promise<void> {
+  const element = document.getElementById(elementId);
+
+  if (!element) {
+    console.warn('Element not found for PDF export, using fallback');
+    const pdf = new jsPDF('p', 'mm', 'a4');
+    pdf.setFontSize(20);
+    pdf.text('Daily Brief Report', 105, 20, { align: 'center' });
+    pdf.setFontSize(12);
+    pdf.text('Content not available', 20, 40);
+    pdf.save(`${filename}.pdf`);
+    return;
+  }
+
+  try {
+    const canvas = await html2canvas(element, {
+      scale: 2,
+      useCORS: true,
+      logging: false,
+      backgroundColor: '#ffffff',
+    });
+
+    const imgData = canvas.toDataURL('image/png');
+    const pdf = new jsPDF('p', 'mm', 'a4');
+
+    const pdfWidth = pdf.internal.pageSize.getWidth();
+    const pdfHeight = pdf.internal.pageSize.getHeight();
+
+    const imgWidth = canvas.width;
+    const imgHeight = canvas.height;
+
+    const ratio = Math.min(pdfWidth / imgWidth, pdfHeight / imgHeight);
+    const imgX = (pdfWidth - imgWidth * ratio) / 2;
+    const imgY = 10;
+
+    pdf.addImage(imgData, 'PNG', imgX, imgY, imgWidth * ratio, imgHeight * ratio);
+    pdf.save(`${filename}.pdf`);
+  } catch (error) {
+    console.error('PDF export failed:', error);
+    const pdf = new jsPDF('p', 'mm', 'a4');
+    pdf.setFontSize(20);
+    pdf.text('Daily Brief Report', 105, 20, { align: 'center' });
+    pdf.setFontSize(12);
+    pdf.text('Export failed - please try again', 20, 40);
+    pdf.save(`${filename}.pdf`);
+  }
+}
+
+export async function exportPDFText(content: string, filename: string) {
+  const pdf = new jsPDF('p', 'mm', 'a4');
+  const pageWidth = pdf.internal.pageSize.getWidth();
+
+  pdf.setFontSize(20);
+  pdf.text('Daily Brief Report', pageWidth / 2, 20, { align: 'center' });
+
+  pdf.setFontSize(12);
+  const lines = content.split('\n');
+  let y = 40;
+
+  lines.forEach((line) => {
+    if (y > 280) {
+      pdf.addPage();
+      y = 20;
+    }
+    pdf.text(line, 10, y);
+    y += 7;
+  });
+
+  pdf.save(`${filename}.pdf`);
+}

--- a/frontend/src/lib/mock-service.ts
+++ b/frontend/src/lib/mock-service.ts
@@ -1,7 +1,5 @@
 import { mockData, Call, CallSummary } from './mock-data';
 import { useAppStore } from '@/stores/app-store';
-import jsPDF from 'jspdf';
-import html2canvas from 'html2canvas';
 
 export interface SearchParams {
   keyword?: string;
@@ -125,112 +123,6 @@ export const MockService = {
     
     useAppStore.getState().addDailyBrief(brief);
     return brief;
-  },
-
-  exportCSV(data: Record<string, unknown>[], filename: string) {
-    if (data.length === 0) return;
-    
-    const headers = Object.keys(data[0]);
-    const csvContent = [
-      headers.join(','),
-      ...data.map((row) =>
-        headers.map((h) => {
-          const val = row[h];
-          if (typeof val === 'string' && (val.includes(',') || val.includes('"'))) {
-            return `"${val.replace(/"/g, '""')}"`;
-          }
-          return val;
-        }).join(',')
-      ),
-    ].join('\n');
-    
-    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `${filename}.csv`;
-    link.click();
-    URL.revokeObjectURL(url);
-  },
-
-  async exportPDF(elementId: string, filename: string): Promise<void> {
-    const element = document.getElementById(elementId);
-    
-    if (!element) {
-      // Fallback to text-based PDF if no element found
-      console.warn('Element not found for PDF export, using fallback');
-      const pdf = new jsPDF('p', 'mm', 'a4');
-      pdf.setFontSize(20);
-      pdf.text('Daily Brief Report', 105, 20, { align: 'center' });
-      pdf.setFontSize(12);
-      pdf.text('Content not available', 20, 40);
-      pdf.save(`${filename}.pdf`);
-      return;
-    }
-
-    try {
-      // Use html2canvas to capture the element
-      const canvas = await html2canvas(element, {
-        scale: 2,
-        useCORS: true,
-        logging: false,
-        backgroundColor: '#ffffff',
-      });
-
-      const imgData = canvas.toDataURL('image/png');
-      const pdf = new jsPDF('p', 'mm', 'a4');
-      
-      const pdfWidth = pdf.internal.pageSize.getWidth();
-      const pdfHeight = pdf.internal.pageSize.getHeight();
-      
-      const imgWidth = canvas.width;
-      const imgHeight = canvas.height;
-      
-      const ratio = Math.min(pdfWidth / imgWidth, pdfHeight / imgHeight);
-      const imgX = (pdfWidth - imgWidth * ratio) / 2;
-      const imgY = 10;
-      
-      pdf.addImage(imgData, 'PNG', imgX, imgY, imgWidth * ratio, imgHeight * ratio);
-      pdf.save(`${filename}.pdf`);
-    } catch (error) {
-      console.error('PDF export failed:', error);
-      // Fallback to text-based PDF
-      const pdf = new jsPDF('p', 'mm', 'a4');
-      pdf.setFontSize(20);
-      pdf.text('Daily Brief Report', 105, 20, { align: 'center' });
-      pdf.setFontSize(12);
-      pdf.text('Export failed - please try again', 20, 40);
-      pdf.save(`${filename}.pdf`);
-    }
-  },
-
-  // Legacy text-based PDF export for backwards compatibility
-  async exportPDFText(content: string, filename: string) {
-    const pdf = new jsPDF('p', 'mm', 'a4');
-    const pageWidth = pdf.internal.pageSize.getWidth();
-    
-    pdf.setFontSize(20);
-    pdf.text('Daily Brief Report', pageWidth / 2, 20, { align: 'center' });
-    
-    pdf.setFontSize(12);
-    const lines = content.split('\n');
-    let y = 40;
-    
-    lines.forEach((line) => {
-      if (y > 280) {
-        pdf.addPage();
-        y = 20;
-      }
-      pdf.text(line, 10, y);
-      y += 7;
-    });
-    
-    pdf.save(`${filename}.pdf`);
-  },
-
-  sendEmailMock(to: string, subject: string, body: string) {
-    useAppStore.getState().addSentEmail({ to, subject, body });
-    return { success: true, message: `Email queued to ${to}` };
   },
 
   generatePostCallTips(call: Call): { tips: string[]; reason: string } {

--- a/frontend/src/pages/supervisor/Briefs.tsx
+++ b/frontend/src/pages/supervisor/Briefs.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useAppStore } from '@/stores/app-store';
+import { exportPDF, exportPDFText, sendEmailMock } from '@/lib/export';
 import { MockService } from '@/lib/mock-service';
 import { toast } from '@/hooks/use-toast';
 import { PageHeader } from '@/components/PageHeader';
@@ -49,7 +50,7 @@ export default function DailyBriefs() {
   const handleExportPDF = async (brief: DailyBrief) => {
     setExporting(true);
     try {
-      await MockService.exportPDF('brief-content', `daily-brief-${brief.date}`);
+      await exportPDF('brief-content', `daily-brief-${brief.date}`);
       toast({
         title: 'PDF Exported',
         description: 'The daily brief has been downloaded as PDF.',
@@ -79,7 +80,7 @@ EXEMPLAR CALLS
 ${brief.content.exemplarLinks.join(', ')}
       `.trim();
 
-      await MockService.exportPDFText(content, `daily-brief-${brief.date}`);
+      await exportPDFText(content, `daily-brief-${brief.date}`);
       toast({
         title: 'PDF Exported',
         description: 'The daily brief has been downloaded as PDF.',
@@ -90,7 +91,7 @@ ${brief.content.exemplarLinks.join(', ')}
   };
 
   const handleEmailBrief = (brief: DailyBrief) => {
-    const result = MockService.sendEmailMock(
+    const result = sendEmailMock(
       'leadership@demo.com',
       `Daily Brief - ${brief.date}`,
       `Daily brief report for ${brief.date}. Total calls: ${brief.content.totalCalls}, Average sentiment: ${brief.content.avgSentiment}`

--- a/frontend/src/pages/supervisor/Search.tsx
+++ b/frontend/src/pages/supervisor/Search.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import type { Call } from '@/lib/mock-data';
+import { exportCSV } from '@/lib/export';
 import { MockService, SearchResult } from '@/lib/mock-service';
 import { callsApi, teamsApi, alertsApi, AgentInfo } from '@/lib/api';
 import { CallDetailDrawer, CallDetailCall } from '@/components/CallDetailDrawer';
@@ -131,7 +132,7 @@ export default function CallSearch() {
       resolved: call.resolved ? 'Yes' : 'No',
     }));
 
-    MockService.exportCSV(data, `call-search-${new Date().toISOString().split('T')[0]}`);
+    exportCSV(data, `call-search-${new Date().toISOString().split('T')[0]}`);
     toast({
       title: 'Export Complete',
       description: `${data.length} calls exported to CSV.`,


### PR DESCRIPTION
# Extract export utilities from MockService

This PR addresses the "mixed responsibilities in `MockService`" item flagged under [TD-08: AI-Assisted Development Code Quality Debt](project-reset/tech-debt-analysis/DEBT_AND_RISK.md) in the Module 1 inventory. CSV export, PDF export, and the email mock are split out of `frontend/src/lib/mock-service.ts` into `frontend/src/lib/export/`.

## Changes

- New `frontend/src/lib/export/csv.ts` — `exportCSV()` pure DOM utility
- New `frontend/src/lib/export/pdf.ts` — `exportPDF()` / `exportPDFText()`; owns the only imports of `jspdf` and `html2canvas`
- New `frontend/src/lib/export/email.ts` — `sendEmailMock()` (still writes to the `useAppStore` sent-emails list)
- New `frontend/src/lib/export/index.ts` — barrel
- `mock-service.ts` — removed the four methods and the top-level `jspdf` / `html2canvas` imports; file is now data-access + brief generation only
- `supervisor/Search.tsx` and `supervisor/Briefs.tsx` — updated to import from `@/lib/export`

---

## VIBE Report

### 1. Target Selected

`frontend/src/lib/mock-service.ts` (the `exportCSV`, `exportPDF`, `exportPDFText`, and `sendEmailMock` methods).

This target fits the "low-risk" criteria from the Module 1 inventory:

- **Isolated.** Call sites were limited to exactly two files — `supervisor/Search.tsx` (CSV) and `supervisor/Briefs.tsx` (PDF + email). No other consumer of `MockService` touches these methods.
- **Well-defined.** Inputs and outputs are concrete: `(data[], filename)` for CSV, `(elementId, filename)` for PDF, `(to, subject, body)` for email. No data-shape ambiguity.
- **Flagged as messy.** TD-08 explicitly calls out "business logic in `mock-service.ts` appears to duplicate similar filtering logic" and the file mixing unrelated concerns. The PDF helpers forced every consumer of `MockService` (including `CallDetailDrawer.tsx` and `Exemplars.tsx`, which only need `getSummary`/`getExemplars`) to transitively load `jspdf` and `html2canvas`.

It is explicitly *not* a core architectural component — auth flow, data schemas, and the Zustand stores were intentionally left alone.

### 2. The Verification Event

The first suggestion from the AI was to keep a symmetric module surface by wrapping the three utilities in a service object and re-exporting a single entry point:

**AI original suggestion**

```ts
// frontend/src/lib/export/index.ts
import jsPDF from 'jspdf';
import html2canvas from 'html2canvas';
import { useAppStore } from '@/stores/app-store';

export const ExportService = {
  exportCSV(...) { ... },
  async exportPDF(...) { ... },
  async exportPDFText(...) { ... },
  sendEmailMock(...) { ... },
};
```

This is idiomatic and mirrors `MockService`, but it **defeats the entire reason for the refactor**. Putting all four utilities behind one object in one module means Vite/Rollup cannot drop `jspdf` and `html2canvas` from chunks that only use `exportCSV` — `Search.tsx` would still pay the PDF bundle cost. It also reintroduces the same Interface-Segregation problem one level lower.

**Final implementation**

One file per format, with the heavy browser-only imports isolated to `pdf.ts`:

```ts
// frontend/src/lib/export/csv.ts  - no jspdf/html2canvas
export function exportCSV(data: Record<string, unknown>[], filename: string) { ... }

// frontend/src/lib/export/pdf.ts  - only module that imports jspdf/html2canvas
import jsPDF from 'jspdf';
import html2canvas from 'html2canvas';
export async function exportPDF(elementId: string, filename: string): Promise<void> { ... }
export async function exportPDFText(content: string, filename: string) { ... }

// frontend/src/lib/export/email.ts  - only module that touches the store
import { useAppStore } from '@/stores/app-store';
export function sendEmailMock(to: string, subject: string, body: string) { ... }

// frontend/src/lib/export/index.ts  - barrel of named re-exports
export { exportCSV } from './csv';
export { exportPDF, exportPDFText } from './pdf';
export { sendEmailMock } from './email';
```

A second audit point worth noting: the AI also suggested "purifying" `sendEmailMock` by returning the payload and letting the caller write to the store. I rejected that because `Briefs.tsx`'s email flow relies on the side-effect reaching `useAppStore.addSentEmail` for the Notifications UI to pick it up — making it pure would have silently changed observable behavior. The extract preserves the original contract exactly.

### 3. Trust Boundary Established

The system is more stable than it was yesterday in four concrete ways:

1. **Reduced import blast radius.** `CallDetailDrawer.tsx`, `Exemplars.tsx`, and any future consumer of `MockService.getSummary` / `getExemplars` / `searchCalls` no longer transitively depend on `jspdf` or `html2canvas`. Only `Briefs.tsx` does.
2. **Testability.** Unit tests for `MockService.searchCalls` or `generateDailyBrief` (future TD-03 work) will not need to stub out `jsPDF` or a DOM `canvas` implementation, because `mock-service.ts` no longer mentions them.
3. **Single responsibility.** `mock-service.ts` is now scoped to data access + brief generation. Export formats live next to each other under `lib/export/` where a new format (e.g. XLSX) can be added without touching the mock service.
4. **Behavior preserved.** No call-site semantics changed; `npx tsc --noEmit` passes with zero errors against a strict-off tsconfig that would otherwise surface any type regression.

### 4. Evidence of Execution

- **Typecheck:** `npx tsc --noEmit` completed with exit code `0`.
- **Lint:** IDE diagnostics report no issues for the new export modules or the updated pages.
- **Runtime:** Loaded `/supervisor/search`, ran a keyword search, and clicked *Export CSV* → file downloads as `call-search-YYYY-MM-DD.csv` with the expected columns. Loaded `/supervisor/briefs`, generated a brief, and exercised both *Export PDF* (image-capture path via `exportPDF`) and *Email brief* (store write via `sendEmailMock`) — both paths behave identically to pre-refactor.
---
